### PR TITLE
update version of fmriprep_app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 **/.DS_Store
 fmriprep_app/opt/license.txt
+fmriprep_app/project.ini
+fmriprep_app/tests/fmriprep-sdc-anat
+fmriprep_app/anat_job-UM.json

--- a/fmriprep_app/app.ini
+++ b/fmriprep_app/app.ini
@@ -2,7 +2,7 @@
 name = fmriprep_LTS
 label = fmriprep_LTS
 description = fMRIPrep is a functional magnetic resonance imaging (fMRI) data preprocessing pipeline
-version = 20.2.1
+version = 20.2.3
 storage_system = a2cps.storage-frontera-protected
 hpc_system = a2cps.hpc-frontera-protected
 queue = corralextra
@@ -15,7 +15,7 @@ dockerfile = Dockerfile
 namespace = jurrutia
 organization = jurrutia
 repo = fmriprep
-tag = 20.2.1.1
+tag = 20.2.3.1
 
 [env]
 


### PR DESCRIPTION
Version 20.2.2 fixed bugs in earlier LTS, as discussed [here](https://confluence.a2cps.org/x/uQ-z). Since then, another version has been released ([20.2.3](https://github.com/nipreps/fmriprep/releases/tag/20.2.3)). This merge lets the fmriprep_app use the most recent version. 

Lines in .gitignore added to accommodate files used locally while testing upgraded version. 

At this point, the new version has been used to process a single participant, UM62121DEV, who finished without errors. This is expected to be safe to merge