### PR TITLE
Remove assertions on EstimatedEffectiveEchoSpacing and EstimatedTotalReadoutTime

### DIFF
--- a/heudiconv_app/assets/utils.py
+++ b/heudiconv_app/assets/utils.py
@@ -237,10 +237,10 @@ def check_dummy_fields_in_appa(b0_json: list):
         ap_data = json.load(a)
         pa_data = json.load(p)
         if not (ap_data["EstimatedTotalReadoutTime"] == pa_data["EstimatedTotalReadoutTime"]):
-            raise AssertionError(f"Not finishing because EstimatedTotalReadoutTime do not match in {ap} and {pa}")                
+            print(f'WARNING: dummy values for EstimatedTotalReadoutTime do not match in {ap} and {pa}.')
             
         if not (ap_data["EstimatedEffectiveEchoSpacing"] == pa_data["EstimatedEffectiveEchoSpacing"]):
-            raise AssertionError(f"Not finishing because EstimatedEffectiveEchoSpacing do not match in {ap} and {pa}")                
+            print(f'WARNING: dummy values for EstimatedEffectiveEchoSpacing do not match in {ap} and {pa}.')
             
 
 def write_dummy_fields(filename: str):


### PR DESCRIPTION
The assertions caused two UC participants to fail, UC10066V1 and UC10133V1. But it's currently unclear whether these values matter for downstream processing. The differences were numerically small, and they were nominally just dummy values, anyway.

For now, they are being removed, but keep a lookout for strange SDC outputs from these participants.

Merging this will allow UC10066V1 and UC10133V1 to proceed with the rest of the pipeline, hopefully passing conversion, bids_validation, and beyond without error