### PR TITLE
use old heudiconv docker image for running UC participants

### DIFF
--- a/heudiconv_app/assets/runner-template.sh
+++ b/heudiconv_app/assets/runner-template.sh
@@ -30,7 +30,37 @@ else
     export DICOM="${FILES}"
 fi
 
-echo singularity exec \
+if [[ "${SITE}" == "UC" ]]; then
+  echo singularity exec \
+    --cleanenv \
+    -B "${BIND_DIR}":"${BIND_DIR}" \
+    docker://jurrutia/heudiconv:0.9.0.1 \
+    heudiconv \
+    ${DICOM_DIR_TEMPLATE} ${DICOM} \
+    ${LIST_OF_SUBJECTS} \
+    ${CONVERTER} \
+    --outdir ${OUTDIR} \
+    ${LOCATOR} ${ANON_CMD} \
+    ${HEURISTIC} \
+    ${SESSION_FOR_LONGITUDINAL} ${BIDS} ${OVERWRITE} \
+    ${DATALAD} ${DCMCONFIG}
+
+  singularity exec \
+    --cleanenv \
+    -B "${BIND_DIR}":"${BIND_DIR}" \
+    docker://jurrutia/heudiconv:0.9.0.1 \
+    heudiconv \
+    ${DICOM_DIR_TEMPLATE} ${DICOM} \
+    ${LIST_OF_SUBJECTS} \
+    ${CONVERTER} \
+    --outdir ${OUTDIR} \
+    ${LOCATOR} ${ANON_CMD} \
+    ${HEURISTIC} \
+    ${SESSION_FOR_LONGITUDINAL} ${BIDS} ${OVERWRITE} \
+    ${DATALAD} ${DCMCONFIG}
+
+else
+  echo singularity exec \
     --cleanenv \
     -B "${BIND_DIR}":"${BIND_DIR}" \
     docker://${CONTAINER_IMAGE} \
@@ -44,7 +74,7 @@ echo singularity exec \
     ${SESSION_FOR_LONGITUDINAL} ${BIDS} ${OVERWRITE} \
     ${DATALAD} ${DCMCONFIG}
 
-singularity exec \
+  singularity exec \
     --cleanenv \
     -B "${BIND_DIR}":"${BIND_DIR}" \
     docker://${CONTAINER_IMAGE} \
@@ -57,6 +87,7 @@ singularity exec \
     ${HEURISTIC} \
     ${SESSION_FOR_LONGITUDINAL} ${BIDS} ${OVERWRITE} \
     ${DATALAD} ${DCMCONFIG}
+fi
 
 # add bval, bvec, betc to .bidsignore
 cat bids_ignore >> "${OUTDIR}"/.bidsignore


### PR DESCRIPTION
Close #24 

30e919efa68713cf0d2d681c7ac4efba0bd94003 updated the docker image used by heudiconv to use a `dcm2niix` patch developed to better handle fmap data coming from GE scanners (v1.0.202100811). However, there was a regression in that version of `dcm2niix` that caused it to stop handling UC dwi data properly. A patch is being developed which will be included in the next stable release, slated for "Fall". In the meantime, this branch uses the last version of dcm2niix known to work (v1.0.20210317). It only uses that version on data coming from UC. 