### PR TITLE
handle WS traveling human naming oddities

### DIFF
--- a/heudiconv_app/assets/a2cps.py
+++ b/heudiconv_app/assets/a2cps.py
@@ -36,6 +36,7 @@ protocols2fix.update({
             # the following finds those files and marks them so that the reproin
             # heuristic can mark duplicate T1w scans 
             ('^T1_MPRAGE_R([1-9])', 'anat-T1w'),
+            ('^T1_MPRAGE R([1-9])', 'anat-T1w'),
             ('^T1_MPRAGE', 'anat-T1w'),
             ('^GE_EPI_B0_(AP|PA)', r'fmap-epi_acq-fmrib0_dir-\1'),
             ('^GE_EPI_B0', 'fmap-epi_acq-fmrib0'),  
@@ -83,7 +84,7 @@ def filter_dicom(dcmdata: pydicom.Dataset) -> bool:
     # want."
     # For T1w, we get both a modified "T1_MPRAGE" and "ORIG T1_MPRAGE". This 
     # prevents the modifed one from going through conversion
-    elif (dcmdata.DeviceSerialNumber == "0007347633TMRFIX" and 
+    elif (dcmdata.__contains__('DeviceSerialNumber') and dcmdata.DeviceSerialNumber == "0007347633TMRFIX" and
       (dcmdata.SeriesDescription == "DTI" or
       dcmdata.SeriesDescription == "DWI" or 
       dcmdata.SeriesDescription == "T1_MPRAGE")):


### PR DESCRIPTION
The traveling human from WS breaks the heudiconv app in two new ways

1) the dicoms did not have a DeviceSerialNumber tag. This is an issue here: https://github.com/a2cps/mri_imaging_pipeline/blob/36e10402b082dfa785a922431f7379f14ef1675a/heudiconv_app/assets/a2cps.py#L86. A solution is only check whether `DeviceSerialNumber == "0007347633TMRFIX" ` when the file contains the DeviceSerialNumber tag.

2) There was a duplicated anatomical, but unlike the present handling at https://github.com/a2cps/mri_imaging_pipeline/blob/36e10402b082dfa785a922431f7379f14ef1675a/heudiconv_app/assets/a2cps.py#L38 , the tag has a space instead of an uderscore (`T1_MPRAGE R2` instead of `T1_MPRAGE_R2`) A solution is to also consider the case of a space.

This pull request implements those solutions