### PR TITLE
allow 0 as valid number of fmrib0 files

### DIFF
--- a/heudiconv_app/assets/utils.py
+++ b/heudiconv_app/assets/utils.py
@@ -120,11 +120,14 @@ def create_fieldmaps(data_path) -> None:
 
     print("Creating fieldmaps for dwi data...")
     output_AP_fname_dwi,output_PA_fname_dwi = create_dwi_b0(dwi_b0_file[0],dwi_file[0])
-
-    print("Renaming fieldmaps for fmri data...")
+    
     fmri_b0_file = glob.glob(os.path.join(sub_dir,sess_name,'fmap','*fmrib0_epi*.nii.gz'))
     fmri_json_file = glob.glob(os.path.join(sub_dir,sess_name,'fmap','*fmrib0_epi*.json'))
-    rename_fmri_b0(fmri_b0_file, fmri_json_file)
+    if len(fmri_b0_file) > 0:
+        print("Renaming fieldmaps for fmri data...")
+        rename_fmri_b0(fmri_b0_file, fmri_json_file)
+    else:
+        print('No fmrib0 found. Nothing to rename')
 
     # remove original fieldmaps from scans.tsv and append new ones
     print("Updating scans.tsv file")


### PR DESCRIPTION
`UI10014V3` had an error

```
Traceback (most recent call last):
  File "create_fieldmaps_GE.py", line 8, in <module>
    create_fieldmaps(fname)
  File "/corral-secure/projects/A2CPS/system/jobs/urrutia/job-bc790d54-8b37-4162-a1ec-78b982b57eff-007-heudiconv-ui10014v3/utils.py", line 182, in create_fieldmaps
    rename_fmri_b0(fmri_b0_file, fmri_json_file)
  File "/corral-secure/projects/A2CPS/system/jobs/urrutia/job-bc790d54-8b37-4162-a1ec-78b982b57eff-007-heudiconv-ui10014v3/utils.py", line 109, in rename_fmri_b0
    raise AssertionError(f"Unexpected number of fmrib0_epi files! Wanted 2, found {n_files}")
AssertionError: Unexpected number of fmrib0_epi files! Wanted 2, found 0
```
caused by this assertion: https://github.com/a2cps/mri_imaging_pipeline/blob/084703c9f602695ec8401f1f1acb29eb0be71b48/heudiconv_app/assets/utils.py#L45-L46

The error was a false alarm, as there were no fmrib0 files to rename.
