### PR TITLE
modifies heuristics to handle atypical names in old phantom, QC_UI040121QA

### DIFF
--- a/heudiconv_app/assets/a2cps.py
+++ b/heudiconv_app/assets/a2cps.py
@@ -70,9 +70,11 @@ protocols2fix.update({
             # also expect ORIG in some DWI (and sometimes also a suffix )
             (".*(b[12]000).*", r"dwi-dwi_acq-\1"),
             ("func-bold_acq-QA", "func_task-rest"),
-            # WS had some atypical names early on
+            # WS/UI had some atypical names early on
             ("REST1_17DSV", "func_task-rest"),
-            ("^Axial GRE scan$", "anat-T1w")
+            ("^Ax.*GRE.*", "anat-T1w"),
+            ("^fMRI QA$", "func_task-rest"),
+            ("^ORIG DWI ([12]000)$", r"dwi-dwi_acq-b\1")
         ],
 })
 
@@ -105,6 +107,15 @@ def filter_dicom(dcmdata: pydicom.Dataset) -> bool:
             dcmdata.SeriesDescription == "anat-T1w_acq-GRE"
         )
     ):
+        exclude = True
+    elif (
+        "QA_4.1.21" in dcmdata.ProtocolName and 
+        (
+            dcmdata.SeriesDescription == "DWI 2000" or
+            dcmdata.SeriesDescription == "DWI 1000"
+        )
+    ):
+        # there is an ORIG DWI [12]000 that must be picked up, but not these
         exclude = True
 
     return exclude

--- a/heudiconv_app/assets/check_acq.py
+++ b/heudiconv_app/assets/check_acq.py
@@ -220,7 +220,7 @@ def main(root: str, site: str, phantom: bool = False, post: bool = False) -> Non
     for scan in T1ws:
       ok *= compare(layout, scan, reference.query("suffix == 'T1w'").copy(), post=post)
   else:
-    print_and_post(f"No T1w scans found when checking jsons in {root}", post=post)
+    print_and_post(f"No T1w scans found when checking jsons in {pathlib.Path(root).absolute()}", post=post)
   
 
   for scan in layout.get(suffix='dwi', extension="nii.gz", return_type="file"):    

--- a/heudiconv_app/assets/runner-template.sh
+++ b/heudiconv_app/assets/runner-template.sh
@@ -153,24 +153,30 @@ else
   sed -i '/_dup/d' ${OUTDIR}/sub-*/ses-*/*scans.tsv
 fi
 
-case "${SITE}" in
-  UI | UM)
-    echo singularity exec \
-      --cleanenv \
-      -B "${BIND_DIR}":"${BIND_DIR}" \
-      docker://${CONTAINER_IMAGE} python3 create_fieldmaps_GE.py "${OUTDIR}"
+if [[ "${PHANTOM}" == "--no-phantom" ]]; then
+  case "${SITE}" in
+    UI | UM)
+      echo singularity exec \
+        --cleanenv \
+        -B "${BIND_DIR}":"${BIND_DIR}" \
+        docker://${CONTAINER_IMAGE} python3 create_fieldmaps_GE.py "${OUTDIR}"
 
-    singularity exec \
-    --cleanenv \
-    -B "${BIND_DIR}":"${BIND_DIR}" \
-      docker://${CONTAINER_IMAGE} python3 create_fieldmaps_GE.py "${OUTDIR}"
+      singularity exec \
+        --cleanenv \
+        -B "${BIND_DIR}":"${BIND_DIR}" \
+        docker://${CONTAINER_IMAGE} python3 create_fieldmaps_GE.py "${OUTDIR}"
 
-    # Adding the correct GE bvals and bvec file. Added on Sept 28,2021.
-    echo "Replacing correct bval and bvec files..."
-    cat correct_bval_GE>"${OUTDIR}"/sub-*/ses-*/dwi/*bval
-    cat correct_bvec_GE>"${OUTDIR}"/sub-*/ses-*/dwi/*bvec
+      # Adding the correct GE bvals and bvec file. Added on Sept 28,2021.
+      echo "Replacing correct bval and bvec files..."
+      cat correct_bval_GE>"${OUTDIR}"/sub-*/ses-*/dwi/*bval
+      cat correct_bvec_GE>"${OUTDIR}"/sub-*/ses-*/dwi/*bvec
     ;;
-esac
+  esac
+else
+  echo "INFO: phantom scan detected. not creating fieldmaps and not replacing bvals/bvecs"
+  # NOTE: not current replacing bvals/bvecs for phantom scans as we don't know what they 
+  # should be (and it's not clear that these values will be helpful)
+fi
 
 echo singularity exec \
   --cleanenv \


### PR DESCRIPTION
https://a2cps-pain.slack.com/archives/C02LG0BRRA9/p1656363701651589

The old phantom used protocolnames that were set before standardization and so weren't picked up by the heuristics. New mappings tested and work with this scan.

Additionally, the warning message has been improved for cases where there is no T1w (hopefully no future cases)
