### PR TITLE
Fix/rotated fmaps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 **/.DS_Store
 fmriprep_app/opt/license.txt
-.vscode
+secrets.json

--- a/heudiconv_app/assets/check_acq.py
+++ b/heudiconv_app/assets/check_acq.py
@@ -11,279 +11,356 @@ from deepdiff import DeepDiff
 
 # parameters to check for numerical equivalence
 FLOATING_PARAMS = {
-  0.001: ["dcmmeta_affine","EffectiveEchoSpacing","RepetitionTime", "ImageOrientationPatientDICOM"],
-  0.01: ["ImagingFrequency","WaterFatShift"],
-  0.1: ["SliceTiming","EchoTime"]
-  }
+    0.001: [
+        "dcmmeta_affine",
+        "EffectiveEchoSpacing",
+        "RepetitionTime",
+        "ImageOrientationPatientDICOM",
+    ],
+    0.01: ["ImagingFrequency", "WaterFatShift"],
+    0.1: ["SliceTiming", "EchoTime"],
+}
 
 
 def post_notification(notification: str, post: bool = False):
-  if post:
-    endpoint = r"https://api.a2cps.org/actors/v2/imaging-slackbot.prod/messages?x-nonce=A2CPS_w1r4M51bYemAQ"
-    content = requests.post(url = endpoint, json = {"text": notification})
-    data = content.json()
-  else:
-    data = None    
-  return data
+    if post:
+        endpoint = r"https://api.a2cps.org/actors/v2/imaging-slackbot.prod/messages?x-nonce=A2CPS_w1r4M51bYemAQ"
+        content = requests.post(url=endpoint, json={"text": notification})
+        data = content.json()
+    else:
+        data = None
+    return data
 
 
 def remove_translation(meta: dict) -> dict:
-  if meta.__contains__('dcmmeta_affine'):
-    affine = meta.get('dcmmeta_affine')
-    for i,row in enumerate(affine):
-      meta['dcmmeta_affine'][i] = row[0:-1]
+    if meta.__contains__("dcmmeta_affine"):
+        affine = meta.get("dcmmeta_affine")
+        for i, row in enumerate(affine):
+            meta["dcmmeta_affine"][i] = row[0:-1]
 
-  return meta
+    return meta
 
 
-def assert_constant(jsons: list, meta:list, key: str, post: bool = False) -> bool:
-  tocheck = pd.DataFrame({
-      'json': [os.path.basename(x) for x in jsons],
-      key: [x.get(key) for x in meta]
-    })
-  
-  if len(tocheck.drop_duplicates(subset=key)) > 1:
-    print_and_post(f"Visit has multiple values for {key}\n" + tocheck.to_string(), post=post)   
-    ok = False
-  else:
-    ok  = True
+def assert_constant(jsons: list, meta: list, key: str, post: bool = False) -> bool:
+    tocheck = pd.DataFrame(
+        {"json": [os.path.basename(x) for x in jsons], key: [x.get(key) for x in meta]}
+    )
 
-  return ok
+    if len(tocheck.drop_duplicates(subset=key)) > 1:
+        print_and_post(
+            f"Visit has multiple values for {key}\n" + tocheck.to_string(), post=post
+        )
+        ok = False
+    else:
+        ok = True
+
+    return ok
 
 
 def compare_withinsub(layout: bids.BIDSLayout, site: str, post: bool = False) -> None:
-  '''
-  Some parameters won't be consistant from participant to participant, even while
-  they should have a single value within a session. This function organizes checks for
-  that consistency
-  
-  '''
-  json_list = layout.get(suffix='T1w', extension="nii.gz", return_type="file") \
-    + layout.get(task='cuff', extension="nii.gz", return_type="file") \
-    + layout.get(task='rest', extension="nii.gz", return_type="file") \
-    + layout.get(suffix='dwi', extension="nii.gz", return_type="file") \
-    + layout.get(suffix='epi', extension="nii.gz", return_type="file")
-  meta_list = [layout.get_metadata(x) for x in json_list]
-  
-  if site in ["NS", "SH"]:
-    ok = assert_constant(json_list, meta_list, "ReceiveCoilActiveElements", post=post)
-    ok *= assert_constant(json_list, meta_list, "ShimSettings", post=post)
-  elif site == "WS":
-    ok = assert_constant(json_list, meta_list, "CoilString", post=post)
-  else:
-    ok = True
+    """
+    Some parameters won't be consistant from participant to participant, even while
+    they should have a single value within a session. This function organizes checks for
+    that consistency
 
-  return ok
+    """
+    json_list = (
+        layout.get(suffix="T1w", extension="nii.gz", return_type="file")
+        + layout.get(task="cuff", extension="nii.gz", return_type="file")
+        + layout.get(task="rest", extension="nii.gz", return_type="file")
+        + layout.get(suffix="dwi", extension="nii.gz", return_type="file")
+        + layout.get(suffix="epi", extension="nii.gz", return_type="file")
+    )
+    meta_list = [layout.get_metadata(x) for x in json_list]
+
+    if site in ["NS", "SH"]:
+        ok = assert_constant(
+            json_list, meta_list, "ReceiveCoilActiveElements", post=post
+        )
+        ok *= assert_constant(json_list, meta_list, "ShimSettings", post=post)
+    elif site == "WS":
+        ok = assert_constant(json_list, meta_list, "CoilString", post=post)
+    else:
+        ok = True
+
+    return ok
 
 
 def check_receivecoil(observed: dict, reference: pd.DataFrame) -> bool:
-  okay_values = reference.ReceiveCoilActiveElements.unique()
-  if not len(okay_values) == 1:
-    raise AssertionError ("Incorrect options for ReceiveCoilActiveElements in reference")
+    okay_values = reference.ReceiveCoilActiveElements.unique()
+    if not len(okay_values) == 1:
+        raise AssertionError(
+            "Incorrect options for ReceiveCoilActiveElements in reference"
+        )
 
-  return observed.get('ReceiveCoilActiveElements') in okay_values[0]
+    return observed.get("ReceiveCoilActiveElements") in okay_values[0]
 
 
 def add_deepkeys(observed: dict) -> dict:
-  if observed.__contains__('global'):
-      observed['BitsStored'] = observed.get('global').get('const').get('BitsStored')
-  return observed
+    if observed.__contains__("global"):
+        observed["BitsStored"] = observed.get("global").get("const").get("BitsStored")
+    return observed
 
 
 def check_bvalsbvecs(
-  bval_observed: np.ndarray, bvec_observed: np.ndarray, 
-  reference: pd.DataFrame,
-  scan: str,
-  post: bool = False) -> bool:  
-  '''
-    in the case of UC scans, we don't get a full dcmstack output in the DWI, so we can't check 
+    bval_observed: np.ndarray,
+    bvec_observed: np.ndarray,
+    reference: pd.DataFrame,
+    scan: str,
+    post: bool = False,
+) -> bool:
+    """
+    in the case of UC scans, we don't get a full dcmstack output in the DWI, so we can't check
     dcmmeta_shape. The length of bvals serves as the check for truncated scans
-    
-    root issue seems to be: https://github.com/moloney/dcmstack/issues/51  
-  '''
-  
-  rb = np.array(pd.eval(reference['bval']), dtype=float).squeeze()
-  rv = np.array(pd.eval(reference['bvec']), dtype=float).squeeze()
-  
-  # in the case of UC scans, we don't get a full dcmstack output in the DWI, so notification must 
-  # happen 
-  # root issue seems to be: https://github.com/moloney/dcmstack/issues/51
-  if bval_observed.shape[0] < rb.shape[0]:
-    print_and_post(f"{os.path.basename(scan)} appears truncated", post=post)
-    ok = False
-  elif not (np.isclose(rb, bval_observed).all() and np.isclose(rv, bvec_observed).all()):
-    print_and_post(f"{os.path.basename(scan)} has unexpected bvals or bvecs", post=post)
-    logging.warning(f"bvals: {bval_observed}")
-    logging.warning(f"bvecs: {bvec_observed}")
-    ok = False
-  else:
-    ok = True
 
-  return ok
+    root issue seems to be: https://github.com/moloney/dcmstack/issues/51
+    """
+
+    rb = np.array(pd.eval(reference["bval"]), dtype=float).squeeze()
+    rv = np.array(pd.eval(reference["bvec"]), dtype=float).squeeze()
+
+    # in the case of UC scans, we don't get a full dcmstack output in the DWI, so notification must
+    # happen
+    # root issue seems to be: https://github.com/moloney/dcmstack/issues/51
+    if bval_observed.shape[0] < rb.shape[0]:
+        print_and_post(f"{os.path.basename(scan)} appears truncated", post=post)
+        ok = False
+    elif not (
+        np.isclose(rb, bval_observed).all() and np.isclose(rv, bvec_observed).all()
+    ):
+        print_and_post(
+            f"{os.path.basename(scan)} has unexpected bvals or bvecs", post=post
+        )
+        logging.warning(f"bvals: {bval_observed}")
+        logging.warning(f"bvecs: {bvec_observed}")
+        ok = False
+    else:
+        ok = True
+
+    return ok
 
 
 def print_and_post(notification: str, post: bool = False) -> None:
-  logging.warning(notification)
-  post_notification(notification, post=post)
+    logging.warning(notification)
+    post_notification(notification, post=post)
 
 
-def compare(layout: bids.BIDSLayout, js_observed: str, reference: pd.DataFrame, post: bool = False) -> bool:
-  ok = True
+def compare(
+    layout: bids.BIDSLayout,
+    js_observed: str,
+    reference: pd.DataFrame,
+    post: bool = False,
+) -> bool:
+    ok = True
 
-  meta = layout.get_metadata(js_observed)
-  meta = add_deepkeys(meta)
+    meta = layout.get_metadata(js_observed)
+    meta = add_deepkeys(meta)
 
-  if reference.scanner.unique()[0] in ["NS", "SH"]:
-    if check_receivecoil(meta, reference):
-      reference.drop(['ReceiveCoilActiveElements'], axis=1, inplace=True)      
-    else:
-      print_and_post(
-        f"{os.path.basename(js_observed)} has unexpected ReceiveCoilActiveElements: {meta.get('ReceiveCoilActiveElements')}",
-        post=post)
-      ok = False
+    if reference.scanner.unique()[0] in ["NS", "SH"]:
+        if check_receivecoil(meta, reference):
+            reference.drop(["ReceiveCoilActiveElements"], axis=1, inplace=True)
+        else:
+            print_and_post(
+                f"{os.path.basename(js_observed)} has unexpected ReceiveCoilActiveElements: {meta.get('ReceiveCoilActiveElements')}",
+                post=post,
+            )
+            ok = False
 
-  # these columns will not be found in any of the jsons. they are mainly indicies used to 
-  # locate rows in the reference table
-  reference.drop(['task', 'suffix', 'acq', 'dir', 'scanner', 'phantom', 'bval', 'bvec'], axis=1, inplace=True)
-  js_goal = reference.dropna(axis=1).copy()
+    # these columns will not be found in any of the jsons. they are mainly indicies used to
+    # locate rows in the reference table
+    reference.drop(
+        ["task", "suffix", "acq", "dir", "scanner", "phantom", "bval", "bvec"],
+        axis=1,
+        inplace=True,
+    )
+    js_goal = reference.dropna(axis=1).copy()
 
-  for n in ['dcmmeta_affine', 'dcmmeta_reorient_transform', 'dcmmeta_shape','SliceTiming']:
-    if n in js_goal.columns.values.tolist():
-      js_goal[n] = pd.eval(js_goal.loc[:,n])
-  
-  js_goal = js_goal.to_dict(orient="records")[0]
-  observed = {key:meta.get(key) for key in js_goal.keys()}
-  observed = remove_translation(observed)
+    for n in [
+        "dcmmeta_affine",
+        "dcmmeta_reorient_transform",
+        "dcmmeta_shape",
+        "SliceTiming",
+    ]:
+        if n in js_goal.columns.values.tolist():
+            js_goal[n] = pd.eval(js_goal.loc[:, n])
 
-  # These are the parameters 
-  for epsilon, params in FLOATING_PARAMS.items():    
-    if any(observed.__contains__(x) for x in params):
-      dd1 = DeepDiff(
-        {key:js_goal[key] for key in params if js_goal.__contains__(key)}, 
-        {key:observed[key] for key in params if js_goal.__contains__(key)}, 
-        math_epsilon=epsilon,
-        ignore_numeric_type_changes=True)
-      if dd1:
+    js_goal = js_goal.to_dict(orient="records")[0]
+    observed = {key: meta.get(key) for key in js_goal.keys()}
+    observed = remove_translation(observed)
+
+    # These are the parameters
+    for epsilon, params in FLOATING_PARAMS.items():
+        if any(observed.__contains__(x) for x in params):
+            dd1 = DeepDiff(
+                {key: js_goal[key] for key in params if js_goal.__contains__(key)},
+                {key: observed[key] for key in params if js_goal.__contains__(key)},
+                math_epsilon=epsilon,
+                ignore_numeric_type_changes=True,
+            )
+            if dd1:
+                ok = False
+                print_and_post(
+                    f"json for {os.path.basename(js_observed)} has unexpected values! Checked with threshold {epsilon}!\n"
+                    + dd1.pretty(),
+                    post=post,
+                )
+
+    dd2 = DeepDiff(
+        {
+            key: js_goal[key]
+            for key in js_goal.keys()
+            if key not in list(chain(*FLOATING_PARAMS.values()))
+        },
+        {
+            key: observed[key]
+            for key in observed.keys()
+            if key not in list(chain(*FLOATING_PARAMS.values()))
+        },
+        ignore_numeric_type_changes=True,
+    )
+
+    if dd2:
+        print_and_post(
+            f"json for {os.path.basename(js_observed)} has unexpected values! Checked with threshold 0\n"
+            + dd2.pretty(),
+            post=post,
+        )
         ok = False
-        print_and_post(f"json for {os.path.basename(js_observed)} has unexpected values! Checked with threshold {epsilon}!\n" + dd1.pretty(), post=post)
+    else:
+        print(f"json for {os.path.basename(js_observed)} looks okay")
+        ok *= True
 
-  dd2 = DeepDiff(
-    {key:js_goal[key] for key in js_goal.keys() if key not in list(chain(*FLOATING_PARAMS.values()))}, 
-    {key:observed[key] for key in observed.keys() if key not in list(chain(*FLOATING_PARAMS.values()))}, 
-    ignore_numeric_type_changes=True)
-
-  if dd2:
-    print_and_post( f"json for {os.path.basename(js_observed)} has unexpected values! Checked with threshold 0\n" + dd2.pretty(), post=post)
-    ok = False
-  else:
-    print(f"json for {os.path.basename(js_observed)} looks okay")
-    ok *= True
-    
-  return ok
+    return ok
 
 
 def getUM(t1w_meta: dict) -> str:
-  if t1w_meta.get("DeviceSerialNumber") == "000000000UM750MR":
-    site = "UM1"
-  elif t1w_meta.get("DeviceSerialNumber") == "0007347633TMRFIX":
-    site = "UM2"
-  else:
-    raise AssertionError ("Unsure which UM bids to compare against!")
+    if t1w_meta.get("DeviceSerialNumber") == "000000000UM750MR":
+        site = "UM1"
+    elif t1w_meta.get("DeviceSerialNumber") == "0007347633TMRFIX":
+        site = "UM2"
+    else:
+        raise AssertionError("Unsure which UM bids to compare against!")
 
-  return site
+    return site
 
 
 def main(root: str, site: str, phantom: bool = False, post: bool = False) -> None:
-  ok = 1
+    ok = 1
 
-  layout = bids.layout.BIDSLayout(root, validate=False)
+    layout = bids.layout.BIDSLayout(root, validate=False)
 
-  if site == "UM":
-    site = getUM(
-      layout.get_metadata(
-        layout.get(suffix='T1w', extension="nii.gz", return_type="file")[0]))
+    if site == "UM":
+        site = getUM(
+            layout.get_metadata(
+                layout.get(suffix="T1w", extension="nii.gz", return_type="file")[0]
+            )
+        )
 
-  reference = (
-    pd.read_csv(
-      "acq-params.tsv", 
-      low_memory=False,
-      delimiter="\t",
-      converters={
-        'ImageOrientationPatientDICOM': pd.eval,
-        'ImageType': pd.eval})
-    .query("scanner == @site & phantom == @phantom" ))
+    reference = pd.read_csv(
+        "acq-params.tsv",
+        low_memory=False,
+        delimiter="\t",
+        converters={"ImageOrientationPatientDICOM": pd.eval, "ImageType": pd.eval},
+    ).query("scanner == @site & phantom == @phantom")
 
-  
-  # T1w is easy and _should_ always be present by now. But if it isn't we still don't want the app to 
-  # fail, so this does a check only if one can be found
-  T1ws = layout.get(suffix='T1w', extension="nii.gz", return_type="file")
-  if len(T1ws) > 0:
-    for scan in T1ws:
-      ok *= compare(layout, scan, reference.query("suffix == 'T1w'").copy(), post=post)
-  else:
-    print_and_post(f"No T1w scans found when checking jsons in {pathlib.Path(root).absolute()}", post=post)
-  
-
-  for scan in layout.get(suffix='dwi', extension="nii.gz", return_type="file"):    
-    # phantom scans have the DWI split into acq-b1000 and acq-b2000, but there is no
-    # acq tag in typical patient scans
-    if phantom:
-      acq = re.findall('acq-(b1000|b2000)', scan)
-      if len(acq) > 0:
-        query = "suffix == 'dwi' & acq == @acq"
-        bval_obs = np.genfromtxt(glob(os.path.join(root, "**","dwi", f"*{acq[0]}*bval"), recursive=True)[0])
-        bvec_obs = np.genfromtxt(glob(os.path.join(root, "**","dwi", f"*{acq[0]}*bvec"), recursive=True)[0])
-      else:
-        # this happens for some (early) SH phantom scans that were collected with the patient protocol
-        print_and_post(f"Expected phantom protocol at {root}, but acq-b1000/acq-b2000 not found", post=post)
-        query = "suffix == 'dwi'" 
-        bval_obs = np.genfromtxt(glob(os.path.join(root, "**","dwi", "*bval"), recursive=True)[0])
-        bvec_obs = np.genfromtxt(glob(os.path.join(root, "**","dwi", "*bvec"), recursive=True)[0])
+    # T1w is easy and _should_ always be present by now. But if it isn't we still don't want the app to
+    # fail, so this does a check only if one can be found
+    T1ws = layout.get(suffix="T1w", extension="nii.gz", return_type="file")
+    if len(T1ws) > 0:
+        for scan in T1ws:
+            ok *= compare(
+                layout, scan, reference.query("suffix == 'T1w'").copy(), post=post
+            )
     else:
-      query = "suffix == 'dwi'" 
-      bval_obs = np.genfromtxt(glob(os.path.join(root, "**","dwi", "*bval"), recursive=True)[0])
-      bvec_obs = np.genfromtxt(glob(os.path.join(root, "**","dwi", "*bvec"), recursive=True)[0])
+        print_and_post(
+            f"No T1w scans found when checking jsons in {pathlib.Path(root).absolute()}",
+            post=post,
+        )
 
-    ok *= check_bvalsbvecs(
-      bval_observed=bval_obs,
-      bvec_observed=bvec_obs,
-      reference=reference.query(query).copy(),
-      scan=scan,
-      post=post)
-    ok *= compare(layout, scan, reference.query(query).copy(), post=post)
+    for scan in layout.get(suffix="dwi", extension="nii.gz", return_type="file"):
+        # phantom scans have the DWI split into acq-b1000 and acq-b2000, but there is no
+        # acq tag in typical patient scans
+        if phantom:
+            acq = re.findall("acq-(b1000|b2000)", scan)
+            if len(acq) > 0:
+                query = "suffix == 'dwi' & acq == @acq"
+                bval_obs = np.genfromtxt(
+                    glob(
+                        os.path.join(root, "**", "dwi", f"*{acq[0]}*bval"),
+                        recursive=True,
+                    )[0]
+                )
+                bvec_obs = np.genfromtxt(
+                    glob(
+                        os.path.join(root, "**", "dwi", f"*{acq[0]}*bvec"),
+                        recursive=True,
+                    )[0]
+                )
+            else:
+                # this happens for some (early) SH phantom scans that were collected with the patient protocol
+                print_and_post(
+                    f"Expected phantom protocol at {root}, but acq-b1000/acq-b2000 not found",
+                    post=post,
+                )
+                query = "suffix == 'dwi'"
+                bval_obs = np.genfromtxt(
+                    glob(os.path.join(root, "**", "dwi", "*bval"), recursive=True)[0]
+                )
+                bvec_obs = np.genfromtxt(
+                    glob(os.path.join(root, "**", "dwi", "*bvec"), recursive=True)[0]
+                )
+        else:
+            query = "suffix == 'dwi'"
+            bval_obs = np.genfromtxt(
+                glob(os.path.join(root, "**", "dwi", "*bval"), recursive=True)[0]
+            )
+            bvec_obs = np.genfromtxt(
+                glob(os.path.join(root, "**", "dwi", "*bvec"), recursive=True)[0]
+            )
 
-  for task in ["rest", "cuff"]:
-    for scan in layout.get(task=task, extension="nii.gz", return_type="file"):
-      ok *= compare(layout, scan, reference.query("suffix == 'bold' & task == @task").copy(), post=post)
-  
-  for fmap in layout.get(extension="nii.gz", return_type="file", suffix="epi"):
-    acq = re.findall('acq-(dwib0|fmrib0)', fmap)[0]
-    dir = re.findall('dir-(AP|PA)', fmap)[0]
-    ok *= compare(
-      layout, 
-      fmap,
-      reference.query("suffix == 'epi' & acq == @acq & dir == @dir").copy(), 
-      post=post)
+        ok *= check_bvalsbvecs(
+            bval_observed=bval_obs,
+            bvec_observed=bvec_obs,
+            reference=reference.query(query).copy(),
+            scan=scan,
+            post=post,
+        )
+        ok *= compare(layout, scan, reference.query(query).copy(), post=post)
 
-  ok *= compare_withinsub(layout, site=site, post=post)
-  if not ok:
-    logging.warning("Unexpected parameters! See logs")
+    for task in ["rest", "cuff"]:
+        for scan in layout.get(task=task, extension="nii.gz", return_type="file"):
+            ok *= compare(
+                layout,
+                scan,
+                reference.query("suffix == 'bold' & task == @task").copy(),
+                post=post,
+            )
 
-  return
+    for fmap in layout.get(extension="nii.gz", return_type="file", suffix="epi"):
+        acq = re.findall("acq-(dwib0|fmrib0)", fmap)[0]
+        dir = re.findall("dir-(AP|PA)", fmap)[0]
+        ok *= compare(
+            layout,
+            fmap,
+            reference.query("suffix == 'epi' & acq == @acq & dir == @dir").copy(),
+            post=post,
+        )
+
+    ok *= compare_withinsub(layout, site=site, post=post)
+    if not ok:
+        logging.warning("Unexpected parameters! See logs")
+
+    return
 
 
-if __name__ == '__main__':
-  parser = argparse.ArgumentParser(description='Check bids.json files')
-  parser.add_argument('root', type=pathlib.Path)
-  parser.add_argument('site', choices=['NS', 'SH', 'UC', 'UI', 'UM', 'WS'])  
-  parser.add_argument(
-    '--phantom', 
-    action=argparse.BooleanOptionalAction, 
-    default=False)  
-  parser.add_argument(
-    '--post', 
-    action=argparse.BooleanOptionalAction,
-    default=False)  
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Check bids.json files")
+    parser.add_argument("root", type=pathlib.Path)
+    parser.add_argument("site", choices=["NS", "SH", "UC", "UI", "UM", "WS"])
+    parser.add_argument(
+        "--phantom", action=argparse.BooleanOptionalAction, default=False
+    )
+    parser.add_argument("--post", action=argparse.BooleanOptionalAction, default=False)
 
-  args = parser.parse_args()  
-  main(root=args.root, site=args.site, phantom=args.phantom, post=args.post)
+    args = parser.parse_args()
+    main(root=args.root, site=args.site, phantom=args.phantom, post=args.post)

--- a/heudiconv_app/assets/edit_json.py
+++ b/heudiconv_app/assets/edit_json.py
@@ -1,5 +1,6 @@
-import sys,json,ast
+import sys
 from utils import edit_json
+
 """
 python3 edit_json.py /scratch/07798/tnath/data/products/development/mris/NS_northshore/bids/NS043021PVP_new_heuristics/
 """

--- a/heudiconv_app/assets/utils.py
+++ b/heudiconv_app/assets/utils.py
@@ -239,7 +239,7 @@ def create_fieldmaps(data_path) -> None:
 
 def save_as_json(data: dict, json_filename: str):
     with open(json_filename, "w") as data_file:
-        json.dump(data, data_file, indent=1, sort_keys=True)
+        json.dump(obj=data, fp=data_file, indent=1, sort_keys=True)
 
 
 def get_manufacturer(dirs: pathlib.Path) -> str:
@@ -265,12 +265,13 @@ def get_manufacturer(dirs: pathlib.Path) -> str:
 
 
 def write_dummy_fields(filename: str):
-    with open(filename, "r+") as f:
+    with open(filename) as f:
         json_data = json.load(f)
         json_data["TotalReadoutTime"] = json_data["EstimatedTotalReadoutTime"]
         json_data["EffectiveEchoSpacing"] = json_data["EstimatedEffectiveEchoSpacing"]
-        save_as_json(json_data, filename)
-        print(f"Added dummy TotalReadoutTime,EffectiveEchoSpacing to {filename}")
+
+    save_as_json(json_data, filename)
+    print(f"Added dummy TotalReadoutTime,EffectiveEchoSpacing to {filename}")
 
 
 def add_intendedfor(json_data: dict, dirs: pathlib.Path, modality: str) -> dict:
@@ -280,7 +281,7 @@ def add_intendedfor(json_data: dict, dirs: pathlib.Path, modality: str) -> dict:
         with open(nii) as n:
             phase_axis_nii = json.load(n).get("PhaseEncodingDirection")[0]
             if phase_axis_nii in json_data.get("PhaseEncodingDirection"):
-                intendedior.append(nii.with_suffix(".nii.gz"))
+                intendedior.append(str(nii.with_suffix(".nii.gz")))
     if len(intendedior) > 0:
         json_data["IntendedFor"] = intendedior
 
@@ -371,7 +372,7 @@ def edit_json(data_path):
 
 def sanitize_json(f) -> None:
     rewrite = False
-    with open(f, "r") as j:
+    with open(f) as j:
         data = json.load(j)
         if (
             data.__contains__("global")

--- a/heudiconv_app/assets/utils.py
+++ b/heudiconv_app/assets/utils.py
@@ -1,10 +1,70 @@
-import os,json,glob,shutil,re
+import os, json, glob, shutil, re
+import pathlib
 from pathlib import Path
-from nilearn.image import load_img,index_img
-from collections import OrderedDict
+from nilearn.image import load_img, index_img
 import pandas as pd
 
-def create_dwi_b0(dwi_b0_file,dwi_file):
+# Hardcoded slice timings to be added to fmri json file. Used only for Philips scanner
+# From Xiaodong: The fMRI sequence in phantom QA is the same as that for subjects scan (June 7th, 2022):
+slice_timing = [
+    0,
+    0.444,
+    0.089,
+    0.533,
+    0.178,
+    0.622,
+    0.267,
+    0.711,
+    0.356,
+    0,
+    0.444,
+    0.089,
+    0.533,
+    0.178,
+    0.622,
+    0.267,
+    0.711,
+    0.356,
+    0,
+    0.444,
+    0.089,
+    0.533,
+    0.178,
+    0.622,
+    0.267,
+    0.711,
+    0.356,
+    0,
+    0.444,
+    0.089,
+    0.533,
+    0.178,
+    0.622,
+    0.267,
+    0.711,
+    0.356,
+    0,
+    0.444,
+    0.089,
+    0.533,
+    0.178,
+    0.622,
+    0.267,
+    0.711,
+    0.356,
+    0,
+    0.444,
+    0.089,
+    0.533,
+    0.178,
+    0.622,
+    0.267,
+    0.711,
+    0.356,
+]
+
+
+def create_dwi_b0(dwi_b0_file, dwi_file):
     """
     Creates fieldmaps for DWI data
     """
@@ -14,57 +74,75 @@ def create_dwi_b0(dwi_b0_file,dwi_file):
     # load images
     b0_imgs = load_img(dwi_b0_file)
     dwi_imgs = load_img(dwi_file)
-    
+
     # most GE scanners give b0 images with 8 volumes (4D image)
     # second UM scanner gives just a single volume (only 3D image)
     if len(b0_imgs.shape) == 4:
-        AP = index_img(b0_imgs,[0,1])
-        PA = index_img(dwi_imgs,[0,1])
+        AP = index_img(b0_imgs, [0, 1])
+        PA = index_img(dwi_imgs, [0, 1])
     else:
         AP = b0_imgs
         PA = index_img(dwi_imgs, 0)
 
     # Save images as AP and PA.
-    output_AP_fname = Path(basepath,str(Path(dwi_b0_file).name).replace('dwib0_epi.nii.gz','dwib0_dir-AP_epi.nii.gz'))
-    print("Saving AP image as %s"%output_AP_fname)
+    output_AP_fname = Path(
+        basepath,
+        str(Path(dwi_b0_file).name).replace(
+            "dwib0_epi.nii.gz", "dwib0_dir-AP_epi.nii.gz"
+        ),
+    )
+    print("Saving AP image as %s" % output_AP_fname)
     AP.to_filename(output_AP_fname)
 
-    output_PA_fname = Path(basepath,str(Path(dwi_b0_file).name).replace('dwib0_epi.nii.gz','dwib0_dir-PA_epi.nii.gz'))
-    print("Saving PA image as %s"%output_PA_fname)
+    output_PA_fname = Path(
+        basepath,
+        str(Path(dwi_b0_file).name).replace(
+            "dwib0_epi.nii.gz", "dwib0_dir-PA_epi.nii.gz"
+        ),
+    )
+    print("Saving PA image as %s" % output_PA_fname)
     PA.to_filename(output_PA_fname)
 
-    return output_AP_fname,output_PA_fname
+    return output_AP_fname, output_PA_fname
 
 
 def rename_fmri_b0(fmri_b0_nifti: list, fmri_b0_json: list) -> None:
-    # rename from epi# to dir-ap or dir-pa based on PhaseEncodingDirection in 
+    # rename from epi# to dir-ap or dir-pa based on PhaseEncodingDirection in
     # sidecar (the labels epi1 vs epi2 are not reliable)
 
     # first, comfirm that dcm2niix/heudiconv produced two files
     n_files = len(fmri_b0_json)
     if not n_files == 2:
-        raise AssertionError(f"Unexpected number of fmrib0_epi files! Wanted 2, found {n_files}")
-    
+        raise AssertionError(
+            f"Unexpected number of fmrib0_epi files! Wanted 2, found {n_files}"
+        )
+
     name_translations = {}
     for filename in fmri_b0_json:
-        with open(filename, 'r') as f:
+        with open(filename, "r") as f:
             data = json.load(f)
-            phaseencoding = data.get("PhaseEncodingDirection")            
+            phaseencoding = data.get("PhaseEncodingDirection")
         if phaseencoding == "j":
-            epi_dir = "dir-PA_epi"                
+            epi_dir = "dir-PA_epi"
         elif phaseencoding == "j-":
             epi_dir = "dir-AP_epi"
         elif phaseencoding is None:
-            raise AssertionError(f"PhaseEncodingDirection not present for {filename}! Don't know how to relabel.")
+            raise AssertionError(
+                f"PhaseEncodingDirection not present for {filename}! Don't know how to relabel."
+            )
         else:
-            raise AssertionError(f"PhaseEncodingDirection set to {phaseencoding}! Don't know what to do with this.")                
+            raise AssertionError(
+                f"PhaseEncodingDirection set to {phaseencoding}! Don't know what to do with this."
+            )
 
-        name_translations.update({re.findall(r"epi\d", filename)[0]: epi_dir})    
+        name_translations.update({re.findall(r"epi\d", filename)[0]: epi_dir})
 
     for src in fmri_b0_nifti + fmri_b0_json:
-        dst = src.replace("epi1", name_translations["epi1"]).replace("epi2", name_translations["epi2"])
+        dst = src.replace("epi1", name_translations["epi1"]).replace(
+            "epi2", name_translations["epi2"]
+        )
         print(f"renaming {src} as {dst}")
-        shutil.move(src, dst) 
+        shutil.move(src, dst)
 
 
 def edit_scansdf(scans_df: pd.DataFrame) -> pd.DataFrame:
@@ -72,27 +150,34 @@ def edit_scansdf(scans_df: pd.DataFrame) -> pd.DataFrame:
     edits scans.tsv file to accomodate newly created and deleted fieldmaps
     """
 
-    out0 = (
-        scans_df
-        .assign(filename=scans_df['filename'].str.replace("epi1","dir-AP_epi").str.replace("epi2","dir-PA_epi"))
+    out0 = scans_df.assign(
+        filename=scans_df["filename"]
+        .str.replace("epi1", "dir-AP_epi")
+        .str.replace("epi2", "dir-PA_epi")
     )
 
-    filenames = out0[['filename']]
-    
-    dwib0 = filenames[filenames.filename.str.contains('dwib0_epi')]
+    filenames = out0[["filename"]]
+
+    dwib0 = filenames[filenames.filename.str.contains("dwib0_epi")]
     ap = pd.DataFrame(
-        dwib0.apply(lambda x: re.sub('dwib0_epi','dwib0_dir-AP_epi', x.filename), axis=1),
-        columns=['filename'])
+        dwib0.apply(
+            lambda x: re.sub("dwib0_epi", "dwib0_dir-AP_epi", x.filename), axis=1
+        ),
+        columns=["filename"],
+    )
     pa = pd.DataFrame(
-        dwib0.apply(lambda x: re.sub('dwib0_epi','dwib0_dir-PA_epi', x.filename), axis=1),
-        columns=['filename'])
+        dwib0.apply(
+            lambda x: re.sub("dwib0_epi", "dwib0_dir-PA_epi", x.filename), axis=1
+        ),
+        columns=["filename"],
+    )
 
     out = (
-        out0[~out0.filename.str.contains('dwib0_epi')]
+        out0[~out0.filename.str.contains("dwib0_epi")]
         .append([ap, pa])
-        .fillna('n/a')
+        .fillna("n/a")
         .reset_index(drop=True)
-        )
+    )
 
     return out
 
@@ -106,38 +191,44 @@ def create_fieldmaps(data_path) -> None:
     dirs = Path(data_path)
 
     # Accessing subject directory, removing hidden directory and sourcedata
-    sub_dir = str(Path(glob.glob(os.path.join(dirs,'sub-*'))[0]))
+    sub_dir = str(Path(glob.glob(os.path.join(dirs, "sub-*"))[0]))
 
     # Getting session name
-    sess_name = os.listdir(sub_dir)[0] # Assuming there is only a single session
+    sess_name = os.listdir(sub_dir)[0]  # Assuming there is only a single session
 
     # Getting nifti files under fmap directory
-    dwi_b0_file = glob.glob(os.path.join(sub_dir,sess_name,'fmap','*dwib0*.nii.gz'))
-    dwi_file = glob.glob(os.path.join(sub_dir,sess_name,'dwi','*dwi*.nii.gz'))
+    dwi_b0_file = glob.glob(os.path.join(sub_dir, sess_name, "fmap", "*dwib0*.nii.gz"))
+    dwi_file = glob.glob(os.path.join(sub_dir, sess_name, "dwi", "*dwi*.nii.gz"))
 
     # Getting json files under fmap directory
-    dwi_json_file = glob.glob(os.path.join(sub_dir,sess_name,'fmap','*dwib0*.json'))
+    dwi_json_file = glob.glob(os.path.join(sub_dir, sess_name, "fmap", "*dwib0*.json"))
 
     print("Creating fieldmaps for dwi data...")
-    output_AP_fname_dwi,output_PA_fname_dwi = create_dwi_b0(dwi_b0_file[0],dwi_file[0])
-    
-    fmri_b0_file = glob.glob(os.path.join(sub_dir,sess_name,'fmap','*fmrib0_epi*.nii.gz'))
-    fmri_json_file = glob.glob(os.path.join(sub_dir,sess_name,'fmap','*fmrib0_epi*.json'))
+    output_AP_fname_dwi, output_PA_fname_dwi = create_dwi_b0(
+        dwi_b0_file[0], dwi_file[0]
+    )
+
+    fmri_b0_file = glob.glob(
+        os.path.join(sub_dir, sess_name, "fmap", "*fmrib0_epi*.nii.gz")
+    )
+    fmri_json_file = glob.glob(
+        os.path.join(sub_dir, sess_name, "fmap", "*fmrib0_epi*.json")
+    )
     if len(fmri_b0_file) > 0:
         print("Renaming fieldmaps for fmri data...")
         rename_fmri_b0(fmri_b0_file, fmri_json_file)
     else:
-        print('No fmrib0 found. Nothing to rename')
+        print("No fmrib0 found. Nothing to rename")
 
     # remove original fieldmaps from scans.tsv and append new ones
     print("Updating scans.tsv file")
-    scans_tsv = glob.glob(os.path.join(sub_dir, sess_name, 'sub-*_scans.tsv'))[0]
-    scans_df = edit_scansdf(pd.read_csv(scans_tsv, sep='\t'))
-    scans_df.to_csv(scans_tsv, sep="\t", index = False)
+    scans_tsv = glob.glob(os.path.join(sub_dir, sess_name, "sub-*_scans.tsv"))[0]
+    scans_df = edit_scansdf(pd.read_csv(scans_tsv, sep="\t"))
+    scans_df.to_csv(scans_tsv, sep="\t", index=False)
 
     print("Creating json files for DWI data...")
-    AP_fname_dwi = str(output_AP_fname_dwi).replace('nii.gz','json')
-    PA_fname_dwi = str(output_PA_fname_dwi).replace('nii.gz','json')
+    AP_fname_dwi = str(output_AP_fname_dwi).replace("nii.gz", "json")
+    PA_fname_dwi = str(output_PA_fname_dwi).replace("nii.gz", "json")
     shutil.copyfile(dwi_json_file[0], AP_fname_dwi)
     shutil.copyfile(dwi_json_file[0], PA_fname_dwi)
 
@@ -146,165 +237,130 @@ def create_fieldmaps(data_path) -> None:
     os.remove(str(dwi_json_file[0]))
 
 
-
-
-def add_fields_to_json(json_data, key, value):
-    """
-    json_data: json data in the form of dictionary
-    key: Name of the key to be added to the json file
-    value: Value of the key to be added
-    """
-    new_dict = OrderedDict()
-    json_data[key]=value
-    # sort the dictionary
-    new_dict = OrderedDict(sorted(json_data.items(), key=lambda t: t[0]))
-
-    # for k, v in json_data.items():
-    #     if k==pos_key:
-    #         new_dict[key] = value  # insert new key
-    #     new_dict[k] = v
-    return new_dict
-
-
 def save_as_json(data: dict, json_filename: str):
-    with open(json_filename, 'w') as data_file:
-         json.dump(data, data_file,indent=1)
+    with open(json_filename, "w") as data_file:
+        json.dump(data, data_file, indent=1, sort_keys=True)
 
 
-def get_manufacturer(json_file: str) -> str:
-    '''
+def get_manufacturer(dirs: pathlib.Path) -> str:
+    """
     extract manufacturer field from json_file
 
     Args:
-        json_file: path to json data, presumably containing the field "manufacturer"
+        dirs: bids root directory
 
     Returns:
         extracted key
 
     Raises:
-        AssertionError: file was opened, but key was not found
-    '''
-    with open(json_file, 'r') as f:
-        json_data = json.load(f)    
-        if not ('Manufacturer' in  json_data.keys()):
-            raise AssertionError("No Manufacturer specified. Post-conversion fixes likely wrong.")
-        manufacturer = json_data['Manufacturer'].lower()
-    return manufacturer
+        AssertionError: key not found in any of the jsons
+    """
+    for i in dirs.glob("sub*/ses*/*/*json"):
+        with open(i, "r") as f:
+            json_data = json.load(f)
+            if json_data.__contains__("Manufacturer"):
+                return json_data["Manufacturer"].lower()
+
+    raise AssertionError("Unable to find json with Manufacturer field")
 
 
 def write_dummy_fields(filename: str):
     with open(filename, "r+") as f:
         json_data = json.load(f)
-        json_data = add_fields_to_json(json_data, 'TotalReadoutTime', json_data["EstimatedTotalReadoutTime"])
-        json_data = add_fields_to_json(json_data, 'EffectiveEchoSpacing', json_data["EstimatedEffectiveEchoSpacing"])
+        json_data["TotalReadoutTime"] = json_data["EstimatedTotalReadoutTime"]
+        json_data["EffectiveEchoSpacing"] = json_data["EstimatedEffectiveEchoSpacing"]
         save_as_json(json_data, filename)
         print(f"Added dummy TotalReadoutTime,EffectiveEchoSpacing to {filename}")
 
 
+def add_intendedfor(json_data: dict, dirs: pathlib.Path, modality: str) -> dict:
+    # add each fmri or dwi to the fmap intendedfor, but only if the phase encoding axes match
+    intendedior = []
+    for nii in dirs.glob(f"sub*/ses*/{modality}/*json"):
+        with open(nii) as n:
+            phase_axis_nii = json.load(n).get("PhaseEncodingDirection")[0]
+            if phase_axis_nii in json_data.get("PhaseEncodingDirection"):
+                intendedior.append(nii.with_suffix(".nii.gz"))
+    if len(intendedior) > 0:
+        json_data["IntendedFor"] = intendedior
+
+    return json_data
+
+
 def edit_json(data_path):
     dirs = Path(data_path)
-    
-    # Hardcoded slice timings to be added to fmri json file. Used only for Philips scanner
-    # From Xiaodong: The fMRI sequence in phantom QA is the same as that for subjects scan (June 7th, 2022): 
-    slice_timing = [0,0.444,0.089,0.533,0.178,0.622,0.267,0.711,0.356,0,0.444,0.089,0.533,
-                   0.178,0.622,0.267,0.711,0.356,0,0.444,0.089,0.533,0.178,0.622,0.267,0.711,0.356,0,0.444,
-                   0.089,0.533,0.178,0.622,0.267,0.711,0.356,0,0.444,0.089,0.533,0.178,0.622,0.267,0.711,
-                   0.356,0,0.444,0.089,0.533,0.178,0.622,0.267,0.711,0.356 ]
-    # Accessing subject directory, removing hidden directory and sourcedata
-    sub_dir = str(Path(glob.glob(os.path.join(dirs,'sub-*'))[0]))
-    # Getting session name
-    sess_name = os.listdir(sub_dir)[0] # Assuming there is only a single session
-    # Getting json and nifti files under dwi and func directories
-    json_files = glob.glob(os.path.join(sub_dir,sess_name,'fmap','*b0*.json'))
-    dwi_json_file = glob.glob(os.path.join(sub_dir,sess_name,'dwi','*dwi*.json'))
-
-    # might be empy in cases where no dwi was run
-    dwi_b0_json = [i for i in json_files if 'dwi' in i]
-
-    func_b0_json = sorted([i for i in json_files if 'fmri' in i])
-    func_json = sorted(glob.glob(os.path.join(sub_dir,sess_name,'func','*.json')))
-    func_data = sorted(glob.glob(os.path.join(sub_dir,sess_name,'func','*.nii.gz')))
 
     # assume that if there was a conversion then there should be at least 1 json
-    manufacturer = get_manufacturer(glob.glob(os.path.join(sub_dir, sess_name, '*', '*.json'))[0])
+    manufacturer = get_manufacturer(dirs)
 
-    print(f"Will try to apply post-conversion fixes specific to images from {manufacturer}...")    
+    print(
+        f"Will try to apply post-conversion fixes specific to images from {manufacturer}"
+    )
 
     # Adding IntendedFor field in the b0 json files for DWI data
-    for i in dwi_b0_json:
-        f=open(i,'r')
-        json_data=json.load(f)
-        if manufacturer in ["philips", "ge"]:
-            if 'AP' in str(Path(i).name):
-                 value = "j-"
-                 json_data = add_fields_to_json(json_data, 'PhaseEncodingDirection', value)
-            else:
-                 value="j"
-                 json_data = add_fields_to_json(json_data, 'PhaseEncodingDirection',  value)
-            print(f"PhaseEncodingDirection for {i} set to {value}")
+    for i in dirs.glob("sub*/ses*/fmap/*dwib0*json"):
+        with open(i) as f:
+            json_data = json.load(f)
 
-        # this could be empty, if, e.g., the b0 was run but then the DWI was skipped
-        dwi_data_files = glob.glob(os.path.join(sub_dir,sess_name,'dwi','*.nii.gz'))
-        value = [os.path.join(sess_name, 'dwi', Path(x).name) for x in dwi_data_files]
-        updated_json = add_fields_to_json(json_data, 'IntendedFor',  value)
-            
-        save_as_json(updated_json, i)
-        print("IntendedField is added to %s"%i)
-        f.close()
+            if manufacturer in ["philips", "ge"]:
+                if "AP" in str(Path(i).name):
+                    value = "j-"
+                else:
+                    value = "j"
+                json_data["PhaseEncodingDirection"] = value
+                print(f"PhaseEncodingDirection for {i} set to {value}")
 
-    for i in dwi_json_file:
-        print(i)
-        f = open(i,'r')
-        json_data=json.load(f)
-        value = "j"
-        updated_json = add_fields_to_json(json_data, 'PhaseEncodingDirection', value)
-        print("PhaseEncodingDirection is added to %s"%i)
-        save_as_json(updated_json,i)
-        f.close()
+            json_data = add_intendedfor(json_data, dirs, "dwi")
+
+        save_as_json(json_data, i)
+        print(f"IntendedField is added to {i}")
+
+    for i in dirs.glob("sub*/ses*/dwi/*dwi*json"):
+        with open(i) as f:
+            json_data = json.load(f)
+            json_data["PhaseEncodingDirection"] = "j"
+
+        save_as_json(json_data, i)
+        print(f"PhaseEncodingDirection is added to {i}")
+
     # Adding IntendedFor field in the json files for rest and cuff data and PhaseEncodingDirection for Philips/GE
-    for i in func_b0_json:
-        f=open(i,'r')
-        json_data=json.load(f)
+    for i in dirs.glob("sub*/ses*/fmap/*fmrib0*json"):
+        with open(i) as f:
+            json_data = json.load(f)
 
-        # Add PhaseEncodingDirection for Philips (not previously present)
-        # fix PhaseEncodingDirection for GE
-        if manufacturer in ["philips"]:
-            if 'AP' in str(Path(i).name):
-                 value = "j-"
-                 json_data = add_fields_to_json(json_data, 'PhaseEncodingDirection',  value)
-            else:
-                 value="j"
-                 json_data = add_fields_to_json(json_data, 'PhaseEncodingDirection', value)
-            print(f"PhaseEncodingDirection for {i} set to {value}")
+            # Add PhaseEncodingDirection for Philips (not previously present)
+            # fix PhaseEncodingDirection for GE
+            if manufacturer in ["philips"]:
+                if "AP" in str(Path(i).name):
+                    value = "j-"
+                else:
+                    value = "j"
+                json_data["PhaseEncodingDirection"] = value
+                print(f"PhaseEncodingDirection for {i} set to {value}")
 
-        # Adds IntendedFor in the json files regardless of any scanner
-        value = [os.path.join(sess_name,'func',str(Path(i).name)) for i in func_data]
-        updated_json = add_fields_to_json(json_data, 'IntendedFor', value)
-        save_as_json(updated_json,i)
-        print("IntendedFor is added to %s"%i)
-        f.close()
+            # Adds IntendedFor in the json files regardless of any scanner
+            json_data = add_intendedfor(json_data, dirs, "func")
+
+        save_as_json(json_data, i)
+        print(f"IntendedFor is added to {i}")
+
     # Add SliceTiming to the json files of rest/cuff json files
     if manufacturer == "philips":
-       for i in func_json:
-           f=open(i,'r')
-           json_data=json.load(f)
-           print(i)
-           value = "j"
-           json_data = add_fields_to_json(json_data, 'PhaseEncodingDirection', value)
+        for i in dirs.glob("sub*/ses*/func/*json"):
+            with open(i) as f:
+                json_data = json.load(f)
+                json_data["PhaseEncodingDirection"] = "j"
+                json_data["SliceTiming"] = slice_timing
 
-           print("PhaseEncodingDirection is added to %s"%i)
-            # Adds sliceTiming for Philips scanner
-           updated_json = add_fields_to_json(json_data, 'SliceTiming', slice_timing)
-           print("SliceTiming is added to %s"%i)
-           save_as_json(updated_json,i)
-           f.close()
+            save_as_json(json_data, i)
+            print(f"PhaseEncodingDirection is added to {i}")
+            print(f"SliceTiming is added to {i}")
 
-    # add parameters missing from philips: TotalReadoutTime, EffectiveEchoSpacing
-    # see: https://confluence.a2cps.org/x/kwnz
-    # these are just dummy values, which works for distortion correction
-    # but the units will not end up scaled correctly
-    if manufacturer == "philips":
-        for filename in dwi_json_file + func_json + func_b0_json + dwi_b0_json:
+        # add parameters missing from philips: TotalReadoutTime, EffectiveEchoSpacing
+        # see: https://confluence.a2cps.org/x/kwnz
+        # these are just dummy values, which works for distortion correction
+        # but the units will not end up scaled correctly
+        for filename in dirs.glob("sub*/ses*/*/*json"):
             write_dummy_fields(filename)
 
     if manufacturer == "siemens":
@@ -318,23 +374,19 @@ def sanitize_json(f) -> None:
     with open(f, "r") as j:
         data = json.load(j)
         if (
-            data.__contains__("global") and 
-            data['global'].__contains__("slices") and 
-            data['global']['slices'].__contains__("DataSetTrailingPadding")
+            data.__contains__("global")
+            and data["global"].__contains__("slices")
+            and data["global"]["slices"].__contains__("DataSetTrailingPadding")
         ):
-            del data['global']["slices"]["DataSetTrailingPadding"]
+            del data["global"]["slices"]["DataSetTrailingPadding"]
             if check_for_null(data):
-                raise AssertionError(f"file {f} still has null characters, which will cause issues downstream")
+                raise AssertionError(
+                    f"file {f} still has null characters, which will cause issues downstream"
+                )
             rewrite = True
     if rewrite:
         save_as_json(data, f)
 
 
 def check_for_null(data: dict) -> bool:
-    return '\\u0000' in json.dumps(data)
-
-
-def get_b0_index(df,bval_value):
-    ind = df.index[df['bvals'] == bval_value].tolist()
-    return ind
-
+    return "\\u0000" in json.dumps(data)


### PR DESCRIPTION
The REST1 scan for one participant was collected with phase encoding axis of `i` rather than `j`, although the fmaps were still collected along the `j` axis. The distortion correction algorithms in fmriprep can't handle this and so the fmriprep-rest job fails. 

These updates restrict the addition of files in the IntendedFor fields to images whose phase encoding axes match the fmaps. 