### PR TITLE
store all qsiprep scratch files through nipype configuration

### DIFF
--- a/qsiprep_app/assets/nipype.cfg
+++ b/qsiprep_app/assets/nipype.cfg
@@ -1,0 +1,2 @@
+[execution]
+remove_unnecessary_outputs = false


### PR DESCRIPTION
For QA/QC, it may be helpful to compare the number of outliers detected by eddy (https://biobank.ctsu.ox.ac.uk/crystal/field.cgi?id=25746). QSIPrep runs `eddy`, but several of the outputs from `eddy` are deleted, including information on the outlier slices. This adds a nipype configuration file to store all outputs from `eddy` (and all other nodes). 