### PR TITLE
store additional cat12 outputs (e.g., unmodulated/concentration)

### DIFF
--- a/cat_app/assets/batch.m
+++ b/cat_app/assets/batch.m
@@ -14,3 +14,13 @@
 % INPUT FILE
 matlabbatch{1}.spm.tools.cat.estwrite.data(1) = '<UNDEFINED>';
 matlabbatch{1}.spm.tools.cat.estwrite.nproc = '<UNDEFINED>';
+
+% GM/WM/CSF/WMH
+matlabbatch{1}.spm.tools.cat.estwrite.output.GM.native = 1;
+matlabbatch{1}.spm.tools.cat.estwrite.output.GM.warped = 1;
+matlabbatch{1}.spm.tools.cat.estwrite.output.GM.mod = 1;
+matlabbatch{1}.spm.tools.cat.estwrite.output.GM.dartel = 1;
+matlabbatch{1}.spm.tools.cat.estwrite.output.WM.native = 1;
+matlabbatch{1}.spm.tools.cat.estwrite.output.WM.warped = 1;
+matlabbatch{1}.spm.tools.cat.estwrite.output.WM.mod = 1;
+matlabbatch{1}.spm.tools.cat.estwrite.output.WM.dartel = 1;


### PR DESCRIPTION
By default, CAT12 stores only the modulated outputs, not the unmodulated ones (e.g., not those matching `wp1sub-<sub>_ses-<ses>_T1w.nii`). This adjusts the batch script to have CAT12 write out the unmodulated results