### PR TITLE
Enh/notify on failure

### DIFF
--- a/aggregator_actor/job.json
+++ b/aggregator_actor/job.json
@@ -25,5 +25,18 @@
     "hiddenOptions": [
         "MEM"
     ],
-    "maxMinutes": 1440
+    "maxMinutes": 1440,
+    "subscriptions": [
+        {
+            "description": "Message on Failure",
+            "enabled": true,
+            "eventCategoryFilter": "JOB_ERROR_MESSAGE",
+            "deliveryTargets": [
+                {
+                    "deliveryMethod": "WEBHOOK",
+                    "deliveryAddress": ""
+                }
+            ]
+        }
+    ]
 }

--- a/aggregator_actor/reactor.py
+++ b/aggregator_actor/reactor.py
@@ -1,13 +1,19 @@
+import copy
 import dataclasses
 import json
 import logging
 import os
 from pathlib import Path
 
-from tapipy import actors, util, errors
-from tapipy.tapis import Tapis
+from tapipy import actors, errors, util
+from tapipy.tapis import Tapis, TapisResult
 
 JOB = Path("/opt/job.json")
+
+
+# TODO
+FAILUREBOT_ADDRESS_SECRET_NAME = ""
+FAILUREBOT_ADDRESS_SECRET_KEY = ""
 
 
 @dataclasses.dataclass
@@ -31,7 +37,9 @@ def actors_get_client() -> Tapis:
     # if we have an access token, use that:
     if token := os.environ.get("_abaco_access_token"):
         tp = Tapis(
-            base_url=os.environ.get("_abaco_api_server", default="").strip("/"),
+            base_url=os.environ.get("_abaco_api_server", default="").strip(
+                "/"
+            ),
             access_token=token,
         )  # type: ignore
     elif server := os.environ.get("_abaco_api_server"):
@@ -45,6 +53,29 @@ def actors_get_client() -> Tapis:
     return tp
 
 
+def get_failurebot_url(client) -> str:
+    token: TapisResult = client.sk.readSecret(  # type: ignore
+        secretType="user",
+        secretName=FAILUREBOT_ADDRESS_SECRET_NAME,
+        tenant=os.environ.get("_tapisTenant"),
+        user=os.environ.get("_tapisEffectiveUserId"),
+    )
+    url: str | None = token.get("secretMap").get(FAILUREBOT_ADDRESS_SECRET_KEY)  # type: ignore
+    if url is None:
+        msg = f"unable to find {FAILUREBOT_ADDRESS_SECRET_KEY} in secretMap"
+        raise AssertionError(msg)
+
+    return url
+
+
+def set_subscription_url(job: dict, arg: str) -> dict:
+    job2 = copy.deepcopy(job)
+    job2.get("subscriptions")[0].get("deliveryTargets")[0].update(  # type: ignore
+        {"deliveryAddress": arg}
+    )
+    return job2
+
+
 def main() -> None:
     context: Context = actors.get_context()  # type: ignore
     print(json.dumps(context, indent=4))
@@ -54,6 +85,8 @@ def main() -> None:
 
     print(json.dumps(job, indent=4))
     client = actors_get_client()
+    failurebot_url = get_failurebot_url(client=client)
+    job = set_subscription_url(job, arg=failurebot_url)
 
     try:
         client.jobs.submitJob(**job)  # type: ignore

--- a/aggregator_actor/reactor.py
+++ b/aggregator_actor/reactor.py
@@ -12,8 +12,8 @@ JOB = Path("/opt/job.json")
 
 
 # TODO
-FAILUREBOT_ADDRESS_SECRET_NAME = ""
-FAILUREBOT_ADDRESS_SECRET_KEY = ""
+FAILUREBOT_ADDRESS_SECRET_NAME = "FAILUREBOT_ADDRESS_SECRET_NAME"
+FAILUREBOT_ADDRESS_SECRET_KEY = "FAILUREBOT_ADDRESS_SECRET_KEY"
 
 
 @dataclasses.dataclass
@@ -57,8 +57,8 @@ def get_failurebot_url(client) -> str:
     token: TapisResult = client.sk.readSecret(  # type: ignore
         secretType="user",
         secretName=FAILUREBOT_ADDRESS_SECRET_NAME,
-        tenant=os.environ.get("_tapisTenant"),
-        user=os.environ.get("_tapisEffectiveUserId"),
+        tenant=os.environ.get("_abaco_api_server").split('.')[0].split("/")[-1],
+        user=client.actors.get_actor(actor_id=os.environ.get("_abaco_actor_id")).owner,
     )
     url: str | None = token.get("secretMap").get(FAILUREBOT_ADDRESS_SECRET_KEY)  # type: ignore
     if url is None:

--- a/aggregator_phantom_actor/job.json
+++ b/aggregator_phantom_actor/job.json
@@ -25,5 +25,18 @@
     "hiddenOptions": [
         "MEM"
     ],
-    "maxMinutes": 100
+    "maxMinutes": 100,
+    "subscriptions": [
+        {
+            "description": "Message on Failure",
+            "enabled": true,
+            "eventCategoryFilter": "JOB_ERROR_MESSAGE",
+            "deliveryTargets": [
+                {
+                    "deliveryMethod": "WEBHOOK",
+                    "deliveryAddress": ""
+                }
+            ]
+        }
+    ]
 }

--- a/aggregator_phantom_actor/reactor.py
+++ b/aggregator_phantom_actor/reactor.py
@@ -10,8 +10,8 @@ from tapipy import actors, errors, util
 from tapipy.tapis import Tapis, TapisResult
 
 # TODO
-FAILUREBOT_ADDRESS_SECRET_NAME = ""
-FAILUREBOT_ADDRESS_SECRET_KEY = ""
+FAILUREBOT_ADDRESS_SECRET_NAME = "FAILUREBOT_ADDRESS_SECRET_NAME"
+FAILUREBOT_ADDRESS_SECRET_KEY = "FAILUREBOT_ADDRESS_SECRET_KEY"
 
 
 # within docker container
@@ -76,8 +76,8 @@ def get_failurebot_url(client) -> str:
     token: TapisResult = client.sk.readSecret(  # type: ignore
         secretType="user",
         secretName=FAILUREBOT_ADDRESS_SECRET_NAME,
-        tenant=os.environ.get("_tapisTenant"),
-        user=os.environ.get("_tapisEffectiveUserId"),
+        tenant=os.environ.get("_abaco_api_server").split('.')[0].split("/")[-1],
+        user=client.actors.get_actor(actor_id=os.environ.get("_abaco_actor_id")).owner,
     )
     url: str | None = token.get("secretMap").get(FAILUREBOT_ADDRESS_SECRET_KEY)  # type: ignore
     if url is None:

--- a/aggregator_phantom_actor/reactor.py
+++ b/aggregator_phantom_actor/reactor.py
@@ -3,11 +3,16 @@ import dataclasses
 import json
 import logging
 import os
-from typing import Any
 from pathlib import Path
+from typing import Any
 
-from tapipy import actors, util, errors
-from tapipy.tapis import Tapis
+from tapipy import actors, errors, util
+from tapipy.tapis import Tapis, TapisResult
+
+# TODO
+FAILUREBOT_ADDRESS_SECRET_NAME = ""
+FAILUREBOT_ADDRESS_SECRET_KEY = ""
+
 
 # within docker container
 JOB = Path("/opt/job.json")
@@ -45,7 +50,9 @@ def actors_get_client() -> Tapis:
     # if we have an access token, use that:
     if token := os.environ.get("_abaco_access_token"):
         tp = Tapis(
-            base_url=os.environ.get("_abaco_api_server", default="").strip("/"),
+            base_url=os.environ.get("_abaco_api_server", default="").strip(
+                "/"
+            ),
             access_token=token,
         )  # type: ignore
     elif server := os.environ.get("_abaco_api_server"):
@@ -65,6 +72,29 @@ def set_outputdir(job: dict, arg: str) -> dict:
     return job2
 
 
+def get_failurebot_url(client) -> str:
+    token: TapisResult = client.sk.readSecret(  # type: ignore
+        secretType="user",
+        secretName=FAILUREBOT_ADDRESS_SECRET_NAME,
+        tenant=os.environ.get("_tapisTenant"),
+        user=os.environ.get("_tapisEffectiveUserId"),
+    )
+    url: str | None = token.get("secretMap").get(FAILUREBOT_ADDRESS_SECRET_KEY)  # type: ignore
+    if url is None:
+        msg = f"unable to find {FAILUREBOT_ADDRESS_SECRET_KEY} in secretMap"
+        raise AssertionError(msg)
+
+    return url
+
+
+def set_subscription_url(job: dict, arg: str) -> dict:
+    job2 = copy.deepcopy(job)
+    job2.get("subscriptions")[0].get("deliveryTargets")[0].update(  # type: ignore
+        {"deliveryAddress": arg}
+    )
+    return job2
+
+
 def main() -> None:
     context: Context = actors.get_context()  # type: ignore
     print(json.dumps(context, indent=4))
@@ -72,8 +102,14 @@ def main() -> None:
 
     with open(JOB, "r") as f:
         job = json.load(f)
-    outdir = context.message_dict.get("OUTDIR", '/corral-secure/projects/A2CPS/community/resources/imaging/phantom/bids')
+    outdir = context.message_dict.get(
+        "OUTDIR",
+        "/corral-secure/projects/A2CPS/community/resources/imaging/phantom/bids",
+    )
     job = set_outputdir(job, outdir)
+    failurebot_url = get_failurebot_url(client=client)
+    job = set_subscription_url(job, arg=failurebot_url)
+
     print(json.dumps(job, indent=4))
 
     try:

--- a/aggregator_qc_actor/job.json
+++ b/aggregator_qc_actor/job.json
@@ -25,5 +25,18 @@
     "hiddenOptions": [
         "MEM"
     ],
-    "maxMinutes": 60
+    "maxMinutes": 60,
+    "subscriptions": [
+        {
+            "description": "Message on Failure",
+            "enabled": true,
+            "eventCategoryFilter": "JOB_ERROR_MESSAGE",
+            "deliveryTargets": [
+                {
+                    "deliveryMethod": "WEBHOOK",
+                    "deliveryAddress": ""
+                }
+            ]
+        }
+    ]
 }

--- a/aggregator_qc_actor/reactor.py
+++ b/aggregator_qc_actor/reactor.py
@@ -10,8 +10,8 @@ from tapipy import actors, errors, util
 from tapipy.tapis import Tapis, TapisResult
 
 # TODO
-FAILUREBOT_ADDRESS_SECRET_NAME = ""
-FAILUREBOT_ADDRESS_SECRET_KEY = ""
+FAILUREBOT_ADDRESS_SECRET_NAME = "FAILUREBOT_ADDRESS_SECRET_NAME"
+FAILUREBOT_ADDRESS_SECRET_KEY = "FAILUREBOT_ADDRESS_SECRET_KEY"
 
 
 # within docker container
@@ -61,8 +61,8 @@ def get_failurebot_url(client) -> str:
     token: TapisResult = client.sk.readSecret(  # type: ignore
         secretType="user",
         secretName=FAILUREBOT_ADDRESS_SECRET_NAME,
-        tenant=os.environ.get("_tapisTenant"),
-        user=os.environ.get("_tapisEffectiveUserId"),
+        tenant=os.environ.get("_abaco_api_server").split('.')[0].split("/")[-1],
+        user=client.actors.get_actor(actor_id=os.environ.get("_abaco_actor_id")).owner,
     )
     url: str | None = token.get("secretMap").get(FAILUREBOT_ADDRESS_SECRET_KEY)  # type: ignore
     if url is None:

--- a/aggregator_qc_actor/reactor.py
+++ b/aggregator_qc_actor/reactor.py
@@ -3,11 +3,16 @@ import dataclasses
 import json
 import logging
 import os
-from typing import Any
 from pathlib import Path
+from typing import Any
 
-from tapipy import actors, util, errors
-from tapipy.tapis import Tapis
+from tapipy import actors, errors, util
+from tapipy.tapis import Tapis, TapisResult
+
+# TODO
+FAILUREBOT_ADDRESS_SECRET_NAME = ""
+FAILUREBOT_ADDRESS_SECRET_KEY = ""
+
 
 # within docker container
 JOB = Path("/opt/job.json")
@@ -36,7 +41,9 @@ def actors_get_client() -> Tapis:
     # if we have an access token, use that:
     if token := os.environ.get("_abaco_access_token"):
         tp = Tapis(
-            base_url=os.environ.get("_abaco_api_server", default="").strip("/"),
+            base_url=os.environ.get("_abaco_api_server", default="").strip(
+                "/"
+            ),
             access_token=token,
         )  # type: ignore
     elif server := os.environ.get("_abaco_api_server"):
@@ -50,6 +57,29 @@ def actors_get_client() -> Tapis:
     return tp
 
 
+def get_failurebot_url(client) -> str:
+    token: TapisResult = client.sk.readSecret(  # type: ignore
+        secretType="user",
+        secretName=FAILUREBOT_ADDRESS_SECRET_NAME,
+        tenant=os.environ.get("_tapisTenant"),
+        user=os.environ.get("_tapisEffectiveUserId"),
+    )
+    url: str | None = token.get("secretMap").get(FAILUREBOT_ADDRESS_SECRET_KEY)  # type: ignore
+    if url is None:
+        msg = f"unable to find {FAILUREBOT_ADDRESS_SECRET_KEY} in secretMap"
+        raise AssertionError(msg)
+
+    return url
+
+
+def set_subscription_url(job: dict, arg: str) -> dict:
+    job2 = copy.deepcopy(job)
+    job2.get("subscriptions")[0].get("deliveryTargets")[0].update(  # type: ignore
+        {"deliveryAddress": arg}
+    )
+    return job2
+
+
 def main() -> None:
     context: Context = actors.get_context()  # type: ignore
     print(json.dumps(context, indent=4))
@@ -57,6 +87,9 @@ def main() -> None:
 
     with open(JOB, "r") as f:
         job = json.load(f)
+
+    failurebot_url = get_failurebot_url(client=client)
+    job = set_subscription_url(job, arg=failurebot_url)
 
     print(json.dumps(job, indent=4))
 

--- a/failure_actor/Dockerfile
+++ b/failure_actor/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.11.4-bullseye
+
+# tapipy 1.4.1 depends on typing_extensions<4.6
+# pydantic>=2.0 depends on typing-extensions>=4.6.1
+RUN pip install --no-cache-dir \
+    tapipy==1.4.1 \
+    "pydantic<2.0"
+
+COPY reactor.py /opt/reactor.py
+
+ENTRYPOINT [ "python" ]
+CMD [ "/opt/reactor.py" ]

--- a/failure_actor/reactor.py
+++ b/failure_actor/reactor.py
@@ -102,8 +102,8 @@ def get_slackbot_url() -> str:
     token: TapisResult = client.sk.readSecret(  # type: ignore
         secretType="user",
         secretName=SLACKBOT_ADDRESS_SECRET_NAME,
-        tenant=os.environ.get("_tapisTenant"),
-        user=os.environ.get("_tapisEffectiveUserId"),
+        tenant=os.environ.get("_abaco_api_server").split('.')[0].split("/")[-1],
+        user=client.actors.get_actor(actor_id=os.environ.get("_abaco_actor_id")).owner,
     )
     url: str | None = token.get("secretMap").get(SLACKBOT_ADDRESS_SECRET_KEY)  # type: ignore
     if url is None:

--- a/failure_actor/reactor.py
+++ b/failure_actor/reactor.py
@@ -7,9 +7,8 @@ from pydantic import BaseModel, Json
 from tapipy import actors, errors, util
 from tapipy.tapis import Tapis, TapisResult
 
-# TODO
-SLACKBOT_ADDRESS_SECRET_NAME = ""
-SLACKBOT_ADDRESS_SECRET_KEY = ""
+SLACKBOT_ADDRESS_SECRET_NAME = "SLACKBOT_ADDRESS_SECRET_NAME"
+SLACKBOT_ADDRESS_SECRET_KEY = "SLACKBOT_ADDRESS_SECRET_KEY"
 
 
 class DeliveryTarget(BaseModel):

--- a/failure_actor/reactor.py
+++ b/failure_actor/reactor.py
@@ -1,0 +1,146 @@
+import datetime
+import os
+import typing
+
+import requests
+from pydantic import BaseModel, Json
+from tapipy import actors, errors, util
+from tapipy.tapis import Tapis, TapisResult
+
+# TODO
+SLACKBOT_ADDRESS_SECRET_NAME = ""
+SLACKBOT_ADDRESS_SECRET_KEY = ""
+
+
+class DeliveryTarget(BaseModel):
+    deliveryMethod: typing.Literal["WEBHOOK", "EMAIL"]
+    deliveryAddress: str
+
+
+class EventData(BaseModel):
+    newJobStatus: str | None
+    oldJobStatus: str | None
+    jobStatus: str | None
+    blockedCount: int
+    remoteJobId: str
+    remoteJobId2: str | None
+    remoteOutcome: str
+    remoteResultInfo: str
+    remoteQueue: str | None
+    remoteSubmitted: datetime.datetime | None
+    remoteStarted: datetime.datetime | None
+    remoteEnded: datetime.datetime | None
+    jobName: str
+    jobUuid: str
+    jobOwner: str
+    message: str
+
+
+class Event(BaseModel):
+    source: str
+    type: str
+    subject: str
+    data: Json[EventData]
+    seriesId: str
+    timestamp: datetime.datetime
+    deleteSubscriptionsMatchingSubject: bool
+    tenant: str
+    user: str
+    uuid: str
+
+
+class Notification(BaseModel):
+    uuid: str
+    tenant: str
+    subscriptionName: str
+    eventUuid: str
+    event: Event
+    deliveryTarget: DeliveryTarget
+    created: datetime.datetime
+
+
+class Context(util.AttrDict):
+    raw_message: str
+    content_type: str
+    actor_repo: str
+    actor_name: str
+    actor_id: str
+    actor_dbid: str
+    execution_id: str
+    worker_id: str
+    username: str
+    state: str
+    raw_message_parse_log: str
+    message_dict: dict[str, typing.Any]
+
+
+def actors_get_client() -> Tapis:
+    """
+    Returns a pre-authenticated Tapis client using the abaco environment variables.
+    """
+    # if we have an access token, use that:
+    if token := os.environ.get("_abaco_access_token"):
+        tp = Tapis(
+            base_url=os.environ.get("_abaco_api_server", default="").strip(
+                "/"
+            ),
+            access_token=token,
+        )  # type: ignore
+    elif server := os.environ.get("_abaco_api_server"):
+        # otherwise, create a client with a fake JWT. this will only work if the actor
+        # supplies its own token to itself via a config object or the message, etc.
+        tp = Tapis(base_url=server.strip("/"), jwt="123")  # type: ignore
+    else:
+        raise errors.BaseTapyException(
+            "Unable to instantiate a Tapis client: no token found."
+        )
+    return tp
+
+
+def get_slackbot_url() -> str:
+    client = actors_get_client()
+
+    token: TapisResult = client.sk.readSecret(  # type: ignore
+        secretType="user",
+        secretName=SLACKBOT_ADDRESS_SECRET_NAME,
+        tenant=os.environ.get("_tapisTenant"),
+        user=os.environ.get("_tapisEffectiveUserId"),
+    )
+    url: str | None = token.get("secretMap").get(SLACKBOT_ADDRESS_SECRET_KEY)  # type: ignore
+    if url is None:
+        msg = f"unable to find {SLACKBOT_ADDRESS_SECRET_KEY} in secretMap"
+        raise AssertionError(msg)
+
+    return url
+
+
+def post_notification(notification: str) -> requests.Response | None:
+    slackbot = get_slackbot_url()
+    return requests.post(url=slackbot, json={"text": notification})
+
+
+def main() -> None:
+    context: Context = actors.get_context()  # type: ignore
+
+    notification = Notification(**context.message_dict)
+
+    msg = f"""
+    Potential failure detected:
+    {
+        notification.event.data.json(
+            indent=2, 
+            include={
+                "remoteSubmitted", 
+                "jobName", 
+                "jobUuid",
+                "message"
+            }
+        )
+    }
+    """
+
+    post_notification(msg)
+
+
+if __name__ == "__main__":
+    main()

--- a/fcn_actor/job.json
+++ b/fcn_actor/job.json
@@ -30,5 +30,18 @@
     "hiddenOptions": [
         "MEM"
     ],
-    "maxMinutes": 1440
+    "maxMinutes": 1440,
+    "subscriptions": [
+        {
+            "description": "Message on Failure",
+            "enabled": true,
+            "eventCategoryFilter": "JOB_ERROR_MESSAGE",
+            "deliveryTargets": [
+                {
+                    "deliveryMethod": "WEBHOOK",
+                    "deliveryAddress": ""
+                }
+            ]
+        }
+    ]
 }

--- a/fcn_actor/reactor.py
+++ b/fcn_actor/reactor.py
@@ -16,9 +16,8 @@ from ibis.expr.types.relations import Table
 from tapipy import actors, errors, util
 from tapipy.tapis import Tapis, TapisResult
 
-# TODO
-FAILUREBOT_ADDRESS_SECRET_NAME = ""
-FAILUREBOT_ADDRESS_SECRET_KEY = ""
+FAILUREBOT_ADDRESS_SECRET_NAME = "FAILUREBOT_ADDRESS_SECRET_NAME"
+FAILUREBOT_ADDRESS_SECRET_KEY = "FAILUREBOT_ADDRESS_SECRET_KEY"
 
 
 # within docker container
@@ -175,8 +174,8 @@ def get_failurebot_url(client) -> str:
     token: TapisResult = client.sk.readSecret(  # type: ignore
         secretType="user",
         secretName=FAILUREBOT_ADDRESS_SECRET_NAME,
-        tenant=os.environ.get("_tapisTenant"),
-        user=os.environ.get("_tapisEffectiveUserId"),
+        tenant=os.environ.get("_abaco_api_server").split('.')[0].split("/")[-1],
+        user=client.actors.get_actor(actor_id=os.environ.get("_abaco_actor_id")).owner,
     )
     url: str | None = token.get("secretMap").get(FAILUREBOT_ADDRESS_SECRET_KEY)  # type: ignore
     if url is None:

--- a/fcn_actor/reactor.py
+++ b/fcn_actor/reactor.py
@@ -1,28 +1,31 @@
 import copy
 import dataclasses
-from datetime import datetime
 import io
 import json
 import logging
 import os
-from typing import Any
+from datetime import datetime
 from pathlib import Path
+from typing import Any
 
-import pandas as pd
 import ibis
-from ibis import _
 import ibis.selectors as s
+import pandas as pd
+from ibis import _
 from ibis.expr.types.relations import Table
+from tapipy import actors, errors, util
+from tapipy.tapis import Tapis, TapisResult
 
+# TODO
+FAILUREBOT_ADDRESS_SECRET_NAME = ""
+FAILUREBOT_ADDRESS_SECRET_KEY = ""
 
-from tapipy import actors, util, errors
-from tapipy.tapis import Tapis
 
 # within docker container
 JOB = Path("/opt/job.json")
 
 # on TACC
-#ILOG = "/corral-secure/projects/A2CPS/community/reports/imaging/imaging-log-latest.csv"
+# ILOG = "/corral-secure/projects/A2CPS/community/reports/imaging/imaging-log-latest.csv"
 ILOG = "/corral-secure/projects/A2CPS/system/cronjob/imaging_report/report.csv"
 
 # can be overriden by incoming message
@@ -61,7 +64,9 @@ def actors_get_client() -> Tapis:
     # if we have an access token, use that:
     if token := os.environ.get("_abaco_access_token"):
         tp = Tapis(
-            base_url=os.environ.get("_abaco_api_server", default="").strip("/"),
+            base_url=os.environ.get("_abaco_api_server", default="").strip(
+                "/"
+            ),
             access_token=token,
         )  # type: ignore
     elif server := os.environ.get("_abaco_api_server"):
@@ -166,6 +171,29 @@ def set_maxminutes(job: dict, maxminutes: int | None = None) -> dict:
     return job2
 
 
+def get_failurebot_url(client) -> str:
+    token: TapisResult = client.sk.readSecret(  # type: ignore
+        secretType="user",
+        secretName=FAILUREBOT_ADDRESS_SECRET_NAME,
+        tenant=os.environ.get("_tapisTenant"),
+        user=os.environ.get("_tapisEffectiveUserId"),
+    )
+    url: str | None = token.get("secretMap").get(FAILUREBOT_ADDRESS_SECRET_KEY)  # type: ignore
+    if url is None:
+        msg = f"unable to find {FAILUREBOT_ADDRESS_SECRET_KEY} in secretMap"
+        raise AssertionError(msg)
+
+    return url
+
+
+def set_subscription_url(job: dict, arg: str) -> dict:
+    job2 = copy.deepcopy(job)
+    job2.get("subscriptions")[0].get("deliveryTargets")[0].update(  # type: ignore
+        {"deliveryAddress": arg}
+    )
+    return job2
+
+
 def main() -> None:
     context: Context = actors.get_context()  # type: ignore
     print(json.dumps(context, indent=4))
@@ -184,10 +212,14 @@ def main() -> None:
     with open(JOB, "r") as f:
         job = json.load(f)
 
-    job = set_fmriprep(job, "--fmriprep-dir " + " ".join(x[0] for x in runlist))
+    job = set_fmriprep(
+        job, "--fmriprep-dir " + " ".join(x[0] for x in runlist)
+    )
     job = set_outputdir(job, "--output-dir " + " ".join(x[1] for x in runlist))
     job = set_maxminutes(job, context.message_dict.get("maxMinutes"))
     job = set_name(job)
+    failurebot_url = get_failurebot_url(client=client)
+    job = set_subscription_url(job, arg=failurebot_url)
 
     print(json.dumps(job, indent=4))
 

--- a/fslanat_actor/job.json
+++ b/fslanat_actor/job.json
@@ -29,5 +29,18 @@
     "hiddenOptions": [
         "MEM"
     ],
-    "maxMinutes": 240
+    "maxMinutes": 240,
+    "subscriptions": [
+        {
+            "description": "Message on Failure",
+            "enabled": true,
+            "eventCategoryFilter": "JOB_ERROR_MESSAGE",
+            "deliveryTargets": [
+                {
+                    "deliveryMethod": "WEBHOOK",
+                    "deliveryAddress": ""
+                }
+            ]
+        }
+    ]
 }

--- a/fslanat_actor/reactor.py
+++ b/fslanat_actor/reactor.py
@@ -15,9 +15,8 @@ from ibis.expr.types.relations import Table
 from tapipy import actors, errors, util
 from tapipy.tapis import Tapis, TapisResult
 
-# TODO
-FAILUREBOT_ADDRESS_SECRET_NAME = ""
-FAILUREBOT_ADDRESS_SECRET_KEY = ""
+FAILUREBOT_ADDRESS_SECRET_NAME = "FAILUREBOT_ADDRESS_SECRET_NAME"
+FAILUREBOT_ADDRESS_SECRET_KEY = "FAILUREBOT_ADDRESS_SECRET_KEY"
 
 
 # within docker container
@@ -198,8 +197,8 @@ def get_failurebot_url(client) -> str:
     token: TapisResult = client.sk.readSecret(  # type: ignore
         secretType="user",
         secretName=FAILUREBOT_ADDRESS_SECRET_NAME,
-        tenant=os.environ.get("_tapisTenant"),
-        user=os.environ.get("_tapisEffectiveUserId"),
+        tenant=os.environ.get("_abaco_api_server").split('.')[0].split("/")[-1],
+        user=client.actors.get_actor(actor_id=os.environ.get("_abaco_actor_id")).owner,
     )
     url: str | None = token.get("secretMap").get(FAILUREBOT_ADDRESS_SECRET_KEY)  # type: ignore
     if url is None:

--- a/fslanat_actor/reactor.py
+++ b/fslanat_actor/reactor.py
@@ -5,21 +5,25 @@ import io
 import json
 import logging
 import os
-from typing import Any, Sequence
 from pathlib import Path
+from typing import Any, Sequence
 
-import pandas as pd
 import ibis
+import pandas as pd
 from ibis import _
 from ibis.expr.types.relations import Table
+from tapipy import actors, errors, util
+from tapipy.tapis import Tapis, TapisResult
 
-from tapipy import actors, util, errors
-from tapipy.tapis import Tapis
+# TODO
+FAILUREBOT_ADDRESS_SECRET_NAME = ""
+FAILUREBOT_ADDRESS_SECRET_KEY = ""
+
 
 # within docker container
 JOB = Path("/opt/job.json")
 # on TACC
-#ILOG = "/corral-secure/projects/A2CPS/community/reports/imaging/imaging-log-latest.csv"
+# ILOG = "/corral-secure/projects/A2CPS/community/reports/imaging/imaging-log-latest.csv"
 ILOG = "/corral-secure/projects/A2CPS/system/cronjob/imaging_report/report.csv"
 
 # can be overriden by incoming message
@@ -78,7 +82,9 @@ def actors_get_client() -> Tapis:
     # if we have an access token, use that:
     if token := os.environ.get("_abaco_access_token"):
         tp = Tapis(
-            base_url=os.environ.get("_abaco_api_server", default="").strip("/"),
+            base_url=os.environ.get("_abaco_api_server", default="").strip(
+                "/"
+            ),
             access_token=token,
         )  # type: ignore
     elif server := os.environ.get("_abaco_api_server"):
@@ -179,11 +185,34 @@ def set_precrop(job: dict, outputdirs: Sequence[str]) -> dict:
     """
     precrop = [outputdir in PRECROP_SUBS for outputdir in outputdirs]
     job2 = copy.deepcopy(job)
-    job2.get("parameterSet").get("appArgs").append(
+    job2.get("parameterSet").get("appArgs").append(  # type: ignore
         {
             "name": "PRECROP",
             "arg": "--precrop " + " ".join(str(x) for x in precrop),
         }
+    )
+    return job2
+
+
+def get_failurebot_url(client) -> str:
+    token: TapisResult = client.sk.readSecret(  # type: ignore
+        secretType="user",
+        secretName=FAILUREBOT_ADDRESS_SECRET_NAME,
+        tenant=os.environ.get("_tapisTenant"),
+        user=os.environ.get("_tapisEffectiveUserId"),
+    )
+    url: str | None = token.get("secretMap").get(FAILUREBOT_ADDRESS_SECRET_KEY)  # type: ignore
+    if url is None:
+        msg = f"unable to find {FAILUREBOT_ADDRESS_SECRET_KEY} in secretMap"
+        raise AssertionError(msg)
+
+    return url
+
+
+def set_subscription_url(job: dict, arg: str) -> dict:
+    job2 = copy.deepcopy(job)
+    job2.get("subscriptions")[0].get("deliveryTargets")[0].update(  # type: ignore
+        {"deliveryAddress": arg}
     )
     return job2
 
@@ -210,6 +239,8 @@ def main() -> None:
     job = set_maxminutes(job, context.message_dict.get("maxMinutes"))
     job = set_name(job)
     job = set_precrop(job, [Path(x[1]).name for x in runlist])
+    failurebot_url = get_failurebot_url(client=client)
+    job = set_subscription_url(job, arg=failurebot_url)
 
     print(json.dumps(job, indent=4))
 

--- a/signatures_actor/job.json
+++ b/signatures_actor/job.json
@@ -1,7 +1,7 @@
 {
     "name": "test_signatures",
     "appId": "urrutia-signatures",
-    "appVersion": "0.2",
+    "appVersion": "0.3",
     "archiveSystemDir": "/corral-secure/projects/A2CPS/products/mris/",
     "parameterSet": {
         "appArgs": [

--- a/signatures_actor/job.json
+++ b/signatures_actor/job.json
@@ -30,5 +30,18 @@
     "hiddenOptions": [
         "MEM"
     ],
-    "maxMinutes": 1440
+    "maxMinutes": 1440,
+    "subscriptions": [
+        {
+            "description": "Message on Failure",
+            "enabled": true,
+            "eventCategoryFilter": "JOB_ERROR_MESSAGE",
+            "deliveryTargets": [
+                {
+                    "deliveryMethod": "WEBHOOK",
+                    "deliveryAddress": ""
+                }
+            ]
+        }
+    ]
 }

--- a/signatures_actor/reactor.py
+++ b/signatures_actor/reactor.py
@@ -1,22 +1,25 @@
 import copy
 import dataclasses
-from datetime import datetime
 import io
 import json
 import logging
 import os
-from typing import Any
+from datetime import datetime
 from pathlib import Path
+from typing import Any
 
-import pandas as pd
 import ibis
-from ibis import _
 import ibis.selectors as s
+import pandas as pd
+from ibis import _
 from ibis.expr.types.relations import Table
+from tapipy import actors, errors, util
+from tapipy.tapis import Tapis, TapisResult
 
+# TODO
+FAILUREBOT_ADDRESS_SECRET_NAME = ""
+FAILUREBOT_ADDRESS_SECRET_KEY = ""
 
-from tapipy import actors, util, errors
-from tapipy.tapis import Tapis
 
 # within docker container
 JOB = Path("/opt/job.json")
@@ -61,7 +64,9 @@ def actors_get_client() -> Tapis:
     # if we have an access token, use that:
     if token := os.environ.get("_abaco_access_token"):
         tp = Tapis(
-            base_url=os.environ.get("_abaco_api_server", default="").strip("/"),
+            base_url=os.environ.get("_abaco_api_server", default="").strip(
+                "/"
+            ),
             access_token=token,
         )  # type: ignore
     elif server := os.environ.get("_abaco_api_server"):
@@ -166,6 +171,29 @@ def set_maxminutes(job: dict, maxminutes: int | None = None) -> dict:
     return job2
 
 
+def get_failurebot_url(client) -> str:
+    token: TapisResult = client.sk.readSecret(  # type: ignore
+        secretType="user",
+        secretName=FAILUREBOT_ADDRESS_SECRET_NAME,
+        tenant=os.environ.get("_tapisTenant"),
+        user=os.environ.get("_tapisEffectiveUserId"),
+    )
+    url: str | None = token.get("secretMap").get(FAILUREBOT_ADDRESS_SECRET_KEY)  # type: ignore
+    if url is None:
+        msg = f"unable to find {FAILUREBOT_ADDRESS_SECRET_KEY} in secretMap"
+        raise AssertionError(msg)
+
+    return url
+
+
+def set_subscription_url(job: dict, arg: str) -> dict:
+    job2 = copy.deepcopy(job)
+    job2.get("subscriptions")[0].get("deliveryTargets")[0].update(  # type: ignore
+        {"deliveryAddress": arg}
+    )
+    return job2
+
+
 def main() -> None:
     context: Context = actors.get_context()  # type: ignore
     print(json.dumps(context, indent=4))
@@ -184,10 +212,14 @@ def main() -> None:
     with open(JOB, "r") as f:
         job = json.load(f)
 
-    job = set_fmriprep(job, "--fmriprep-dir " + " ".join(x[0] for x in runlist))
+    job = set_fmriprep(
+        job, "--fmriprep-dir " + " ".join(x[0] for x in runlist)
+    )
     job = set_outputdir(job, "--output-dir " + " ".join(x[1] for x in runlist))
     job = set_maxminutes(job, context.message_dict.get("maxMinutes"))
     job = set_name(job)
+    failurebot_url = get_failurebot_url(client=client)
+    job = set_subscription_url(job, arg=failurebot_url)
 
     print(json.dumps(job, indent=4))
 

--- a/signatures_actor/reactor.py
+++ b/signatures_actor/reactor.py
@@ -17,8 +17,8 @@ from tapipy import actors, errors, util
 from tapipy.tapis import Tapis, TapisResult
 
 # TODO
-FAILUREBOT_ADDRESS_SECRET_NAME = ""
-FAILUREBOT_ADDRESS_SECRET_KEY = ""
+FAILUREBOT_ADDRESS_SECRET_NAME = "FAILUREBOT_ADDRESS_SECRET_NAME"
+FAILUREBOT_ADDRESS_SECRET_KEY = "FAILUREBOT_ADDRESS_SECRET_KEY"
 
 
 # within docker container
@@ -175,8 +175,8 @@ def get_failurebot_url(client) -> str:
     token: TapisResult = client.sk.readSecret(  # type: ignore
         secretType="user",
         secretName=FAILUREBOT_ADDRESS_SECRET_NAME,
-        tenant=os.environ.get("_tapisTenant"),
-        user=os.environ.get("_tapisEffectiveUserId"),
+        tenant=os.environ.get("_abaco_api_server").split('.')[0].split("/")[-1],
+        user=client.actors.get_actor(actor_id=os.environ.get("_abaco_actor_id")).owner,
     )
     url: str | None = token.get("secretMap").get(FAILUREBOT_ADDRESS_SECRET_KEY)  # type: ignore
     if url is None:

--- a/signatures_app/app.json
+++ b/signatures_app/app.json
@@ -1,6 +1,6 @@
 {
     "id": "urrutia-signatures",
-    "version": "0.2",
+    "version": "0.3",
     "description": "Multivariate Pattern Signatures",
     "owner": "${apiUserId}",
     "enabled": true,
@@ -9,7 +9,7 @@
     "runtimeOptions": [
         "SINGULARITY_RUN"
     ],
-    "containerImage": "docker://a2cps/signatures_app:3.1",
+    "containerImage": "docker://a2cps/signatures_app:3.2",
     "jobType": "BATCH",
     "maxJobs": -1,
     "maxJobsPerUser": -1,


### PR DESCRIPTION
Notification service appears to be working. To deploy

- [x] build new failure_actor image
- [x] deploy new failure_actor
- [x] create secret associated with the url for the slackbot (including nonce)
- [x] fill [slackbot secrets](https://github.com/a2cps/mri_imaging_pipeline/blob/986b035f6b9dc1423b69ce895608f5c08329b257/failure_actor/reactor.py#L11-L12) 
- [x] create nonce for the new "failurebot" (failure_actor)
- [x] create secret associated with the url to the failurebot 
- [x] fill failurebot secrets for aggregator_actor (e.g., https://github.com/a2cps/mri_imaging_pipeline/blob/986b035f6b9dc1423b69ce895608f5c08329b257/aggregator_actor/reactor.py#L14-L16)
- [x] fill failurebot secrets for aggregator_phantom_actor
- [x] fill failurebot secrets for aggregator_qc_actor
- [x] fill failurebot secrets for fcn_actor
- [x] fill failurebot secrets for fslanat_actor
- [x] fill failurebot secrets for signatures_actor
- [x] rebuild image and redeploy aggregator_actor
- [x] rebuild image and redeploy aggregator_phantom_actor
- [x] rebuild image and redeploy aggregator_qc_actor
- [x] rebuild image and redeploy fcn_actor
- [x] rebuild image and redeploy fslanat_actor
- [x] rebuild image and redeploy signatures_actor
