### PR TITLE
avoid trying to extract patientname from dicomdir file

### DIFF
--- a/dicom_reader_app/assets/file_check.py
+++ b/dicom_reader_app/assets/file_check.py
@@ -69,7 +69,7 @@ def find_dicom(filename: str, isZip: bool) -> str:
     if isZip:
         site_zip = zipfile.ZipFile(filename)
         for listing in site_zip.infolist():
-            if not listing.is_dir():  # and 'DICOMDIR' not in listing.orig_filename
+            if (not listing.is_dir()) and ("DICOMDIR" not in listing.orig_filename):
                 break
         dicom_file = site_zip.extract(listing)
         return dicom_file


### PR DESCRIPTION
RU sends an extra DICOMDIR file. This file has the field PatientName, but it is buried in a place that pydicom does not pick up through the usual loading means. 

```python
> import pydicom
> dicom = pydicom.dcmread("DICOMDIR")
> dicom.PatientName
#[...]
AttributeError: 'DicomDir' object has no attribute 'PatientName'
```
This pull request ensures DICOMDIR is not used as a source of PatientName