### PR TITLE
handle longer than expected dwi

### DIFF
--- a/heudiconv_app/assets/check_acq.py
+++ b/heudiconv_app/assets/check_acq.py
@@ -179,6 +179,11 @@ def check_bvalsbvecs(
             f"{os.path.basename(scan)} appears truncated", post=post
         )
         ok = False
+    elif bval_observed.shape[0] > rb.shape[0]:
+        print_and_post(
+            f"{os.path.basename(scan)} appears atypically long", post=post
+        )
+        ok = False
     elif not (
         np.isclose(rb, bval_observed).all()
         and np.isclose(rv, bvec_observed).all()


### PR DESCRIPTION
We have [a check for truncated bvals](https://github.com/a2cps/mri_imaging_pipeline/blob/35fb7d35bc2d457a1d2383d57e7380f0ecab9384/heudiconv_app/assets/check_acq.py#L177-L186), but there is nothing that anticipates a longer series. Looks like the new traveling human scan had 103 instead of 102 volumes

```shell
$ wc WStravel2/sub-travel2/ses-WS2/dwi/sub-travel2_ses-WS2_dwi.bval 
  1 103 488 WStravel2/sub-travel2/ses-WS2/dwi/sub-travel2_ses-WS2_dwi.bval
$ wc WStravel2/sub-travel2/ses-WS/dwi/sub-travel2_ses-WS_dwi.bval 
  1 102 481 WStravel2/sub-travel2/ses-WS/dwi/sub-travel2_ses-WS_dwi.bval
and this tripped up the bids checker
```