### PR TITLE
Fix/fmriprep actor outputdir arg length

### DIFF
--- a/fmriprep_actor/job.json
+++ b/fmriprep_actor/job.json
@@ -13,10 +13,6 @@
                 "name": "INPUT_DIRS"
             },
             {
-                "arg": "--output-dirs NS_northshore/fmriprep/NStravel1 NS_northshore/fmriprep/NStravel2  RU_rush/fmriprep/RUtravel1 RU_rush/fmriprep/RUtravel2 SH_spectrum_health/fmriprep/SHtravel2 UC_uchicago/fmriprep/UCtravel1 UC_uchicago/fmriprep/UCtravel2 UI_uic/fmriprep/UItravel1 UI_uic/fmriprep/UItravel2 UM_umichigan/fmriprep/UM1travel2 UM_umichigan/fmriprep/UM2travel2 WS_wayne_state/fmriprep/WStravel2",
-                "name": "OUTPUT_DIRS"
-            },
-            {
                 "arg": "--anat-only False False False False False False False False False False False False",
                 "name": "ANAT_ONLY"
             },

--- a/fmriprep_actor/reactor.py
+++ b/fmriprep_actor/reactor.py
@@ -106,6 +106,7 @@ def get_ilog(client: Tapis) -> Table:
                 "1st Resting State Received": bool,
                 "2nd Resting State Received": bool,
             },
+            parse_dates=["acquisition_week"],
         )
     )
 
@@ -147,7 +148,7 @@ def get_runlist(
             + "/bids/"
             + x.sublong  # type: ignore
         )
-        .order_by(["visit", "subject_id"])  # ensure V1 run before V3
+        .order_by(["visit", "acquisition_week"])  # ensure V1 run before V3
         .execute()
     )
 

--- a/fmriprep_actor/reactor.py
+++ b/fmriprep_actor/reactor.py
@@ -111,9 +111,7 @@ def get_ilog(client: Tapis) -> Table:
     )
 
 
-def get_runlist(
-    ilog: Table, maxjobs: int = MAXJOBS
-) -> list[tuple[str, str, str]]:
+def get_runlist(ilog: Table, maxjobs: int = MAXJOBS) -> list[tuple[str, str]]:
     rundef = (
         ilog.select(
             "site",
@@ -141,7 +139,6 @@ def get_runlist(
             sitelong=_.site.cases(tuple(SITE_LONG.items())),  # type: ignore
             ANAT_ONLY=ibis.or_(_.CUFF1, _.CUFF2, _.REST1, _.REST2).negate(),
         )
-        .mutate(OUTPUT_DIR=_.sitelong + "/fmriprep/" + _.sublong)  # type: ignore
         .mutate(
             INPUT_DIR=lambda x: "/corral-secure/projects/A2CPS/products/mris/"
             + x.sitelong
@@ -153,10 +150,9 @@ def get_runlist(
     )
 
     runlist = [
-        (x, y, str(z))
-        for x, y, z in zip(
+        (x, str(z))
+        for x, z in zip(
             rundef.INPUT_DIR.to_list(),
-            rundef.OUTPUT_DIR.to_list(),
             rundef.ANAT_ONLY.to_list(),
         )
     ]
@@ -243,14 +239,8 @@ def main() -> None:
     job = set_app_arg(
         job,
         1,
-        name="OUTPUT_DIRS",
-        arg="--output-dirs " + " ".join(x[1] for x in runlist),
-    )
-    job = set_app_arg(
-        job,
-        2,
         name="ANAT_ONLY",
-        arg="--anat-only " + " ".join(x[2] for x in runlist),
+        arg="--anat-only " + " ".join(x[1] for x in runlist),
     )
 
     job = set_env_var(


### PR DESCRIPTION
When running large jobs (e.g., 64 nodes), the command line generated by the fmriprep app ends up very long. We suspect that the length of the line is causing the app to fail.

This prevents the OUTPUT_DIR arg from being set by the fmriprep_actor. The fmriprep_app can generate a valid output_dir based on the input_dir.

```shell
$ cat b83bd2fa-3858-4289-82e0-013030095700-007.err 

Inactive Modules:
  1) python3

The following have been reloaded with a version change:
  1) impi/19.0.9 => impi/21.12     2) intel/19.1.1 => intel/24.1

INFO:    Using cached SIF image
[mpiexec@c301-010.ls6.tacc.utexas.edu] cmd_bcast_root (../../../../../src/pm/i_hydra/mpiexec/mpiexec.c:180): assert (!closed) failed
[mpiexec@c301-010.ls6.tacc.utexas.edu] push_mapping_info_downstream (../../../../../src/pm/i_hydra/mpiexec/mpiexec.c:745): error pushing generic command downstream
[mpiexec@c301-010.ls6.tacc.utexas.edu] main (../../../../../src/pm/i_hydra/mpiexec/mpiexec.c:1930): error setting up the pmi process mapping propagation

# *out
TACC:  Shutdown complete. Exiting. 
TACC:  Starting up job 1928179 
TACC:  Starting parallel tasks... 
TACC:  MPI job exited with code: 141 
TACC:  Shutdown complete. Exiting. 
```
