### PR TITLE
Fix/fmriprep failures

### DIFF
--- a/fmriprep_actor/Dockerfile
+++ b/fmriprep_actor/Dockerfile
@@ -1,8 +1,9 @@
 FROM python:3.11.9-bullseye
 
 RUN pip install --no-cache-dir \
-    tapipy==1.6.3 \
-    ibis-framework[duckdb]==9.1.0 
+    git+https://github.com/a2cps/mri-actor-utils.git@eca6bc1334dfd3d35d0b4d3a543a779750bc3b20 \
+    && pip uninstall -y polars \
+    && pip --no-cache-dir install polars-lts-cpu==1.8.2
 
 
 COPY reactor.py /opt/reactor.py

--- a/fmriprep_actor/job.json
+++ b/fmriprep_actor/job.json
@@ -3,7 +3,7 @@
     "appVersion": "3.1",
     "cmdPrefix": "ibrun -n 12",
     "coresPerNode": 6,
-    "maxMinutes": 960,
+    "maxMinutes": 1200,
     "name": "fmriprep",
     "nodeCount": 2,
     "archiveSystemDir": "/corral-secure/projects/A2CPS/products/mris",

--- a/fmriprep_actor/reactor.py
+++ b/fmriprep_actor/reactor.py
@@ -1,29 +1,21 @@
-import copy
-import dataclasses
 import datetime
-import io
-import json
 import logging
-import os
+import json
 from pathlib import Path
-import math
-import typing
 
 import ibis
-import pandas as pd
 from ibis import _
-from ibis.expr.types.relations import Table
-from tapipy import actors, errors, util
-from tapipy.tapis import Tapis, TapisResult
+
+from mri_actor_utils import config, models
 
 FAILUREBOT_ADDRESS_SECRET_NAME = "FAILUREBOT_ADDRESS_SECRET_NAME"
 FAILUREBOT_ADDRESS_SECRET_KEY = "FAILUREBOT_ADDRESS_SECRET_KEY"
-
 
 # within docker container
 JOB = Path("/opt/job.json")
 
 # on TACC
+# can be changed from this default by specifying "ILOG" in actor message
 ILOG = "/corral-secure/projects/A2CPS/shared/urrutia/imaging_report/imaging_log.csv"
 
 # numbers for ls6
@@ -41,249 +33,138 @@ MAXJOBS = N_SUBS_PER_NODE * MAX_NODES_PER_JOB
 # prolonged runtime
 N_SEC_TO_COPY_ONE_SUB = 180
 
-SITE_LONG = {
-    "NS": "NS_northshore",
-    "UI": "UI_uic",
-    "UC": "UC_uchicago",
-    "UM": "UM_umichigan",
-    "SH": "SH_spectrum_health",
-    "WS": "WS_wayne_state",
-    "RU": "RU_rush",
-}
+# NOTE: the job.json parameters --n-workers and --mem-mb are not modified
+#       so, best to set them according to the maximum number of subs
+#       that could be run on a single node
 
 
-@dataclasses.dataclass
-class Context(util.AttrDict):
-    raw_message: str
-    content_type: str
-    actor_repo: str
-    actor_name: str
-    actor_id: str
-    actor_dbid: str
-    execution_id: str
-    worker_id: str
-    username: str
-    state: str
-    raw_message_parse_log: str
-    message_dict: dict[str, typing.Any]
+class FMRIPrepReactor(models.Reactor):
 
-
-def actors_get_client() -> Tapis:
-    """
-    Returns a pre-authenticated Tapis client using the abaco environment variables.
-    """
-    # if we have an access token, use that:
-    if token := os.environ.get("_abaco_access_token"):
-        tp = Tapis(
-            base_url=os.environ.get("_abaco_api_server", default="").strip(
-                "/"
-            ),
-            access_token=token,
-        )  # type: ignore
-    elif server := os.environ.get("_abaco_api_server"):
-        # otherwise, create a client with a fake JWT. this will only work if the actor
-        # supplies its own token to itself via a config object or the message, etc.
-        tp = Tapis(base_url=server.strip("/"), jwt="123")  # type: ignore
-    else:
-        raise errors.BaseTapyException(
-            "Unable to instantiate a Tapis client: no token found."
+    def get_runlist(self) -> list[tuple[str, str]]:
+        rundef = (
+            self.ilog.select(
+                "site",
+                "subject_id",
+                "visit",
+                "bids",
+                "fmriprep",
+                "acquisition_week",
+            )
+            .rename(
+                {
+                    "CUFF1": "fMRI Individualized Pressure Received",
+                    "CUFF2": "fMRI Standard Pressure Received",
+                    "REST1": "1st Resting State Received",
+                    "REST2": "2nd Resting State Received",
+                }
+            )
+            .filter(_.bids == 1)  # type: ignore
+            .filter(_.fmriprep == 0)  # type: ignore
+            .mutate(
+                sublong=_.site.concat(_.subject_id, _.visit),  # type: ignore
+                sitelong=_.site.cases(tuple(config.SITE_LONG.items())),  # type: ignore
+                ANAT_ONLY=ibis.or_(
+                    _.CUFF1, _.CUFF2, _.REST1, _.REST2  # type: ignore
+                ).negate(),
+            )
+            .mutate(
+                INPUT_DIR=lambda x: "/corral-secure/projects/A2CPS/products/mris/"
+                + x.sitelong
+                + "/bids/"
+                + x.sublong  # type: ignore
+            )
+            .order_by(
+                ["visit", "acquisition_week"]
+            )  # ensure V1 run before V3, and do oldest scans
+            .execute()
         )
-    return tp
 
+        runlist = [
+            (x, str(z))
+            for x, z in zip(
+                rundef.INPUT_DIR.to_list(),
+                rundef.ANAT_ONLY.to_list(),
+            )
+        ]
+        return runlist[
+            : self.context.message_dict.get("MAXJOBS", self.MAXJOBS)
+        ]
 
-def get_ilog(client: Tapis) -> Table:
-    ilog: bytes = client.files.getContents(  # type: ignore
-        systemId="secure.ls6", path=ILOG
-    )
-    return ibis.memtable(
-        pd.read_csv(
-            io.BytesIO(ilog),
-            na_values=["na", ""],
-            dtype={
-                "subject_id": str,
-                "fMRI Individualized Pressure Received": bool,
-                "fMRI Standard Pressure Received": bool,
-                "1st Resting State Received": bool,
-                "2nd Resting State Received": bool,
-            },
-            parse_dates=["acquisition_week"],
+    def submit(self) -> None:
+        print(json.dumps(self.context, indent=4))
+
+        runlist = self.get_runlist()
+        n_jobs = len(runlist)
+        if not n_jobs:
+            logging.warning("Did not find any jobs to submit")
+            return
+
+        n_nodes = self.get_node_count(n_jobs)
+        self.set_app_arg(
+            name="INPUT_DIRS",
+            value="--input-dirs " + " ".join(x[0] for x in runlist),
         )
-    )
-
-
-def get_runlist(ilog: Table, maxjobs: int = MAXJOBS) -> list[tuple[str, str]]:
-    rundef = (
-    ilog.select(
-            "site",
-            "subject_id",
-            "visit",
-            "bids",
-            "fmriprep",
-            "fMRI Individualized Pressure Received",
-            "fMRI Standard Pressure Received",
-            "1st Resting State Received",
-            "2nd Resting State Received",
-            "acquisition_week"
+        self.set_app_arg(
+            name="ANAT_ONLY",
+            value="--input-dirs " + " ".join(x[1] for x in runlist),
         )
-        .rename(
-            {
-                "CUFF1": "fMRI Individualized Pressure Received",
-                "CUFF2": "fMRI Standard Pressure Received",
-                "REST1": "1st Resting State Received",
-                "REST2": "2nd Resting State Received",
-            }
+
+        self.set_env_var(
+            key="MIN_ARCHIVE_DURATION",
+            value=str(n_jobs * self.N_SEC_TO_COPY_ONE_SUB),
         )
-        .filter(_.bids == 1)  # type: ignore
-        .filter(_.fmriprep == 0)  # type: ignore
-        .mutate(
-            sublong=_.site.concat(_.subject_id, _.visit),  # type: ignore
-            sitelong=_.site.cases(tuple(SITE_LONG.items())),  # type: ignore
-            ANAT_ONLY=ibis.or_(_.CUFF1, _.CUFF2, _.REST1, _.REST2).negate(),
+        if max_minutes := self.context.message_dict.get("maxMinutes"):
+            self.job.maxMinutes = max_minutes
+
+        self.job.name = self.job_name
+
+        self.set_cmd_prefix(image=self.container_image, n_jobs=n_jobs)
+
+        # corresponds to SBATCH option -N,--nodes, SLURM_JOB_NUM_NODES
+        self.job.nodeCount = n_nodes
+
+        # corresponds to SBATCH option -n,--ntask, SLURM_NPROCS, SLURM_NTASKS
+        # all nodes will have all cores available, but this needs to be set for ibrun
+        self.job.coresPerNode = self.N_SUBS_PER_NODE
+
+        if self.context.message_dict.get("SKIP_FAILUREBOT", False):
+            self.job.subscriptions = None
+        else:
+            self.set_subscription_url(url=self.failurebot_url)
+
+        if FAILURE_LOG_DST := self.context.message_dict.get("FAILURE_LOG_DST"):
+            self.set_env_var(
+                key="FAILURE_LOG_DST",
+                value=FAILURE_LOG_DST,
+            )
+
+        print(
+            self.job.model_dump_json(
+                indent=4, exclude_unset=True, exclude_none=True
+            )
         )
-        .mutate(
-            INPUT_DIR=lambda x: "/corral-secure/projects/A2CPS/products/mris/"
-            + x.sitelong
-            + "/bids/"
-            + x.sublong  # type: ignore
-        )
-        .order_by(["visit", "acquisition_week"])  # ensure V1 run before V3
-        .execute()
-    )
 
-    runlist = [
-        (x, str(z))
-        for x, z in zip(
-            rundef.INPUT_DIR.to_list(),
-            rundef.ANAT_ONLY.to_list(),
-        )
-    ]
-    return runlist[:maxjobs]
-
-
-def get_node_count(n_jobs: int) -> int:
-    return math.ceil(n_jobs / N_SUBS_PER_NODE)
-
-
-def get_cmd_prefix(image: str, n_jobs: int) -> str:
-    return f"ibrun -n 1 apptainer run {image} --help && ibrun -n {n_jobs}"
-
-
-def set_app_arg(job: dict, arg_pos: int, name: str, arg: str) -> dict:
-    job2 = copy.deepcopy(job)
-    job2.get("parameterSet").get("appArgs")[arg_pos] = {"name": name, "arg": arg}  # type: ignore
-    return job2
-
-
-def set_env_var(job: dict, arg_pos: int, key: str, value: str) -> dict:
-    job2 = copy.deepcopy(job)
-    job2.get("parameterSet").get("envVariables")[arg_pos] = {"key": key, "value": value}  # type: ignore
-    return job2
-
-
-def set_key_value(job: dict, key: str, value: int | str | None = None) -> None:
-    if value:
-        job[key] = value
-
-
-def get_failurebot_url(client) -> str:
-    token: TapisResult = client.sk.readSecret(  # type: ignore
-        secretType="user",
-        secretName=FAILUREBOT_ADDRESS_SECRET_NAME,
-        tenant=os.environ.get("_abaco_api_server")
-        .split(".")[0]  # type: ignore
-        .split("/")[-1],
-        user=client.actors.get_actor(
-            actor_id=os.environ.get("_abaco_actor_id")
-        ).owner,
-    )
-    url: str | None = token.get("secretMap").get(FAILUREBOT_ADDRESS_SECRET_KEY)  # type: ignore
-    if url is None:
-        msg = f"unable to find {FAILUREBOT_ADDRESS_SECRET_KEY} in secretMap"
-        raise AssertionError(msg)
-
-    return url
-
-
-def set_subscription_url(job: dict, arg: str) -> dict:
-    job2 = copy.deepcopy(job)
-    job2.get("subscriptions")[0].get("deliveryTargets")[0].update(  # type: ignore
-        {"deliveryAddress": arg}
-    )
-    return job2
+        try:
+            submitted = self.client.jobs.submitJob(  # type: ignore
+                **self.job.model_dump(exclude_unset=True, exclude_none=True)
+            )
+            print(submitted.uuid)
+        except Exception as e:
+            logging.exception(f"encountered while trying to submit job: {e}")
 
 
 def main() -> None:
-    context: Context = actors.get_context()  # type: ignore
-    print(json.dumps(context, indent=4))
-    client = actors_get_client()
-
-    ilog = get_ilog(client=client)
-
-    runlist = get_runlist(
-        ilog=ilog, maxjobs=context.message_dict.get("maxjobs", MAXJOBS)
+    reactor = FMRIPrepReactor(
+        job_name=f"fmriprep-{datetime.datetime.today().strftime('%Y-%m-%d')}",
+        FAILUREBOT_ADDRESS_SECRET_KEY=FAILUREBOT_ADDRESS_SECRET_KEY,
+        FAILUREBOT_ADDRESS_SECRET_NAME=FAILUREBOT_ADDRESS_SECRET_NAME,
+        N_SUBS_PER_NODE=N_SUBS_PER_NODE,
+        N_SEC_TO_COPY_ONE_SUB=N_SEC_TO_COPY_ONE_SUB,
+        ILOG=Path(ILOG),
+        JOB=JOB,
+        MAXJOBS=MAXJOBS,
     )
-    if not len(runlist):
-        logging.warning("Did not find any jobs to submit")
-        return
-
-    with open(JOB, "r") as f:
-        job = json.load(f)
-
-    n_jobs = len(runlist)
-    n_nodes = get_node_count(n_jobs)
-    job = set_app_arg(
-        job,
-        0,
-        name="INPUT_DIRS",
-        arg="--input-dirs " + " ".join(x[0] for x in runlist),
-    )
-    job = set_app_arg(
-        job,
-        1,
-        name="ANAT_ONLY",
-        arg="--anat-only " + " ".join(x[1] for x in runlist),
-    )
-
-    job = set_env_var(
-        job,
-        arg_pos=0,
-        key="MIN_ARCHIVE_DURATION",
-        value=str(n_jobs * N_SEC_TO_COPY_ONE_SUB),
-    )
-
-    set_key_value(
-        job, key="maxMinutes", value=context.message_dict.get("maxMinutes")
-    )
-    set_key_value(
-        job,
-        key="name",
-        value=f"fmriprep-{datetime.datetime.today().strftime('%Y-%m-%d')}",
-    )
-
-    image = client.apps.getApp(
-        appId=job["appId"], appVersion=job["appVersion"]
-    ).containerImage
-    set_key_value(
-        job, key="cmdPrefix", value=get_cmd_prefix(n_jobs=n_jobs, image=image)
-    )
-
-    # corresponds to SBATCH option -N,--nodes, SLURM_JOB_NUM_NODES
-    set_key_value(job, key="nodeCount", value=n_nodes)
-
-    # corresponds to SBATCH option -n,--ntask, SLURM_NPROCS, SLURM_NTASKS
-    # all nodes will have all cores available, but this needs to be set for ibrun
-    set_key_value(job, key="coresPerNode", value=N_SUBS_PER_NODE)
-
-    failurebot_url = get_failurebot_url(client=client)
-    job = set_subscription_url(job, arg=failurebot_url)
-
-    print(json.dumps(job, indent=4))
-
-    try:
-        submitted = client.jobs.submitJob(**job)  # type: ignore
-        print(submitted.uuid)
-    except Exception as e:
-        logging.error(f"encountered while trying to submit job: {e}")
+    reactor.submit()
 
 
 if __name__ == "__main__":

--- a/fmriprep_actor/reactor.py
+++ b/fmriprep_actor/reactor.py
@@ -3,8 +3,7 @@ import logging
 import json
 from pathlib import Path
 
-import ibis
-from ibis import _
+import polars as pl
 
 from mri_actor_utils import config, models
 
@@ -42,48 +41,47 @@ class FMRIPrepReactor(models.Reactor):
 
     def get_runlist(self) -> list[tuple[str, str]]:
         rundef = (
-            self.ilog.select(
-                "site",
-                "subject_id",
-                "visit",
-                "bids",
-                "fmriprep",
-                "acquisition_week",
-            )
-            .rename(
+            self.ilog.rename(
                 {
-                    "CUFF1": "fMRI Individualized Pressure Received",
-                    "CUFF2": "fMRI Standard Pressure Received",
-                    "REST1": "1st Resting State Received",
-                    "REST2": "2nd Resting State Received",
+                    "fMRI Individualized Pressure Received": "CUFF1",
+                    "fMRI Standard Pressure Received": "CUFF2",
+                    "1st Resting State Received": "REST1",
+                    "2nd Resting State Received": "REST2",
                 }
             )
-            .filter(_.bids == 1)  # type: ignore
-            .filter(_.fmriprep == 0)  # type: ignore
-            .mutate(
-                sublong=_.site.concat(_.subject_id, _.visit),  # type: ignore
-                sitelong=_.site.cases(tuple(config.SITE_LONG.items())),  # type: ignore
-                ANAT_ONLY=ibis.or_(
-                    _.CUFF1, _.CUFF2, _.REST1, _.REST2  # type: ignore
-                ).negate(),
+            .filter(pl.col("T1 Received") == 1)
+            .filter(pl.col("bids") == 1)
+            .filter(pl.col("fmriprep") == 0)
+            .with_columns(
+                sublong=pl.concat_str(
+                    pl.col("site"), pl.col("subject_id"), pl.col("visit")
+                ),
+                sitelong=pl.col("site").replace(config.SITE_LONG),
+                ANAT_ONLY=(
+                    (pl.col("CUFF1") == 0)
+                    & (pl.col("CUFF2") == 0)
+                    & (pl.col("REST1") == 0)
+                    & (pl.col("REST2") == 0)
+                ),
             )
-            .mutate(
-                INPUT_DIR=lambda x: "/corral-secure/projects/A2CPS/products/mris/"
-                + x.sitelong
-                + "/bids/"
-                + x.sublong  # type: ignore
+            .with_columns(
+                INPUT_DIR=pl.concat_str(
+                    pl.lit("/corral-secure/projects/A2CPS/products/mris/"),
+                    pl.col("sitelong"),
+                    pl.lit("/bids/"),
+                    pl.col("sublong"),
+                )
             )
-            .order_by(
-                ["visit", "acquisition_week"]
+            .sort(
+                "visit", "acquisition_week"
             )  # ensure V1 run before V3, and do oldest scans
-            .execute()
         )
 
         runlist = [
             (x, str(z))
             for x, z in zip(
-                rundef.INPUT_DIR.to_list(),
-                rundef.ANAT_ONLY.to_list(),
+                rundef.select(pl.col("INPUT_DIR")).to_series().to_list(),
+                rundef.select(pl.col("ANAT_ONLY")).to_series().to_list(),
             )
         ]
         return runlist[

--- a/fmriprep_app/Dockerfile
+++ b/fmriprep_app/Dockerfile
@@ -29,17 +29,17 @@ SHELL ["/usr/local/bin/_dockerfile_shell.sh"]
 ENV ENV_NAME=fmriprep
 
 RUN micromamba install -q --name ${ENV_NAME} --yes -c conda-forge --freeze-installed \
-        impi_rt=2021.12 \
-        ucx=1.17.0 \
-        rdma-core=52.0 \
-        mpi4py=3.1.6 \
-        polars=1.0.0 \
-        pydantic=2.8.0 \
-        pytorch=2.3.1 \
+    impi_rt=2021.12 \
+    ucx=1.17.0 \
+    rdma-core=52.0 \
+    mpi4py=3.1.6 \
+    polars=1.0.0 \
+    pydantic=2.8.0 \
+    pytorch=2.3.1 \
     && micromamba run -n ${ENV_NAME} pip install \
-        --no-deps \
-        mriqc==24.0.0 \
-        git+https://github.com/a2cps/biomarker-extractor.git@2fb859247424a8a4d170188b48d1ebe890bb0f30 \
+    --no-deps \
+    mriqc==24.0.0 \
+    git+https://github.com/a2cps/biomarker-extractor.git@fb02069bd428ca24df51e0adec32ef1bdf90ed3c \
     && micromamba clean --all --yes
 
 COPY --from=fs --chown=$MAMBA_USER:$MAMBA_USER /freesurfer/models/synthstrip.1.pt /opt/synthstrip.1.pt


### PR DESCRIPTION
fMRIPrep has been failing, but the failed jobs are being deposited into /products (and the logs don't make it to log_dst_dir). This was an issue with how the fmriprep subprocess failures were being captured, resolved with these updates