### PR TITLE
ENH: tar mriqc outputs

### DIFF
--- a/cronjobs/unpack/cronjob
+++ b/cronjobs/unpack/cronjob
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -euo pipefail
+
+extract_inplace() {
+  local src="$1"
+  local parent
+  parent=$(dirname "${src}")
+
+  tar --directory "${parent}" -xvf "${src}"
+}
+export -f extract_inplace
+
+mris=/corral-secure/projects/A2CPS/products/mris
+
+find ${mris} \
+    -mindepth 4 \
+    -maxdepth 4 \
+    -name "uuid*rank*tar" \
+    -exec bash -c 'extract_inplace "$@";' -- {} \;
+

--- a/cronjobs/unpack/cronjob
+++ b/cronjobs/unpack/cronjob
@@ -7,7 +7,8 @@ extract_inplace() {
   local parent
   parent=$(dirname "${src}")
 
-  tar --directory "${parent}" -xvf "${src}"
+  tar --directory "${parent}" -xvf "${src}" \
+    && rm -v "${src}"
 }
 export -f extract_inplace
 

--- a/mriqc_app/Dockerfile
+++ b/mriqc_app/Dockerfile
@@ -35,7 +35,7 @@ RUN micromamba install -q --name ${ENV_NAME} --yes -c conda-forge --freeze-insta
     polars=1.5.0 \
     pydantic=2.8.2 \
     && micromamba run -n ${ENV_NAME} pip install --no-deps \
-    git+https://github.com/a2cps/biomarker-extractor.git@55c6c1f957fe46d1f01dd7af5c9439fe1154d4c9 \
+    git+https://github.com/a2cps/biomarker-extractor.git@036c09ef317e6cc1fa6a13e3186c16eb811ff071 \
     && micromamba clean --all --yes
 
 # files searched for in entrypoint.py

--- a/mriqc_app/Dockerfile
+++ b/mriqc_app/Dockerfile
@@ -1,5 +1,5 @@
 # bring in the micromamba image so we can copy files from it
-FROM mambaorg/micromamba:1.5.8 AS micromamba
+FROM mambaorg/micromamba:1.5 AS micromamba
 
 FROM nipreps/mriqc:24.0.2
 
@@ -28,19 +28,18 @@ SHELL ["/usr/local/bin/_dockerfile_shell.sh"]
 ENV ENV_NAME=base
 
 RUN micromamba install -q --name ${ENV_NAME} --yes -c conda-forge --freeze-installed \
-        impi_rt=2021.12 \
-        ucx=1.17.0 \
-        rdma-core=52.0 \
-        mpi4py=3.1.6 \
-        polars=1.2.1 \
-        pydantic=2.8.2 \
-    && micromamba run -n ${ENV_NAME} pip install \
-        --no-deps \
-        git+https://github.com/a2cps/biomarker-extractor.git@476e59dc5e1bf54cf86028cbf55a9ef4d8b489ce \
+    impi_rt=2021.12 \
+    ucx=1.17.0 \
+    rdma-core=52.0 \
+    mpi4py=3.1.6 \
+    polars=1.5.0 \
+    pydantic=2.8.2 \
+    && micromamba run -n ${ENV_NAME} pip install --no-deps \
+    git+https://github.com/a2cps/biomarker-extractor.git@55c6c1f957fe46d1f01dd7af5c9439fe1154d4c9 \
     && micromamba clean --all --yes
 
 # files searched for in entrypoint.py
-COPY assets/entrypoint.py /opt/mriqc_app/
+COPY --chown=${MAMBA_USER}:${MAMBA_USER} assets/entrypoint.py /opt/mriqc_app/
 ENV TZ=US/Central
 
 ENTRYPOINT ["/usr/local/bin/_entrypoint.sh", "python", "/opt/mriqc_app/entrypoint.py"]

--- a/mriqc_app/tests/job_travel.json
+++ b/mriqc_app/tests/job_travel.json
@@ -3,13 +3,13 @@
     "appVersion": "3.0",
     "cmdPrefix": "ibrun -n 13",
     "coresPerNode": 13,
-    "maxMinutes": 60,
+    "maxMinutes": 120,
     "name": "mriqc",
     "nodeCount": 1,
     "parameterSet": {
         "appArgs": [
             {
-                "arg": "--input-dirs /corral-secure/projects/A2CPS/shared/psadil/jobs/travel-bids/NS_northshore/bids/NStravel1 /corral-secure/projects/A2CPS/shared/psadil/jobs/travel-bids/NS_northshore/bids/NStravel2 /corral-secure/projects/A2CPS/shared/psadil/jobs/travel-bids/RU_rush/bids/RUtravel1 /corral-secure/projects/A2CPS/shared/psadil/jobs/travel-bids/RU_rush/bids/RUtravel2 /corral-secure/projects/A2CPS/shared/psadil/jobs/travel-bids/SH_spectrum_health/bids/SHtravel2 /corral-secure/projects/A2CPS/shared/psadil/jobs/travel-bids/UC_uchicago/bids/UCtravel1 /corral-secure/projects/A2CPS/shared/psadil/jobs/travel-bids/UC_uchicago/bids/UCtravel2 /corral-secure/projects/A2CPS/shared/psadil/jobs/travel-bids/UI_uic/bids/UItravel1 /corral-secure/projects/A2CPS/shared/psadil/jobs/travel-bids/UI_uic/bids/UItravel2 /corral-secure/projects/A2CPS/shared/psadil/jobs/travel-bids/UM_umichigan/bids/UM1travel2 /corral-secure/projects/A2CPS/shared/psadil/jobs/travel-bids/UM_umichigan/bids/UM2travel2 /corral-secure/projects/A2CPS/shared/psadil/jobs/travel-bids/WS_wayne_state/bids/WStravel2 /corral-secure/projects/A2CPS/shared/psadil/jobs/travel-bids/WS_wayne_state/bids/WS2travel2",
+                "arg": "--input-dirs /corral-secure/projects/A2CPS/community/resources/imaging/traveling/NS_northshore/bids/NStravel1 /corral-secure/projects/A2CPS/community/resources/imaging/traveling/NS_northshore/bids/NStravel2 /corral-secure/projects/A2CPS/community/resources/imaging/traveling/RU_rush/bids/RUtravel1 /corral-secure/projects/A2CPS/community/resources/imaging/traveling/RU_rush/bids/RUtravel2 /corral-secure/projects/A2CPS/community/resources/imaging/traveling/SH_spectrum_health/bids/SHtravel2 /corral-secure/projects/A2CPS/community/resources/imaging/traveling/UC_uchicago/bids/UCtravel1 /corral-secure/projects/A2CPS/community/resources/imaging/traveling/UC_uchicago/bids/UCtravel2 /corral-secure/projects/A2CPS/community/resources/imaging/traveling/UI_uic/bids/UItravel1 /corral-secure/projects/A2CPS/community/resources/imaging/traveling/UI_uic/bids/UItravel2 /corral-secure/projects/A2CPS/community/resources/imaging/traveling/UM_umichigan/bids/UM1travel2 /corral-secure/projects/A2CPS/community/resources/imaging/traveling/UM_umichigan/bids/UM2travel2 /corral-secure/projects/A2CPS/community/resources/imaging/traveling/WS_wayne_state/bids/WStravel2 /corral-secure/projects/A2CPS/community/resources/imaging/traveling/WS_wayne_state/bids/WS2travel2",
                 "name": "INPUT_DIRS"
             },
             {


### PR DESCRIPTION
When this is fully tested, the other mpi apps can be updated to the same version of (https://github.com/a2cps/biomarker-extractor/pull/5) -- fingers crossed that no other changes would be necessary