### PR TITLE
Closes #320

### DIFF
--- a/heudiconv_app/env.yml
+++ b/heudiconv_app/env.yml
@@ -158,14 +158,14 @@ dependencies:
   - orc=1.9.2=h7829240_1
   - ordered-set=4.1.0=pyhd8ed1ab_0
   - orjson=3.9.10=py311h34b1e23_0
-  - packaging=23.2=pyhd8ed1ab_0
+  - packaging=24.1=pyhd8ed1ab_0
   - pandas=2.2.0=py311h320fe9a_0
   - pango=1.50.14=ha41ecd1_2
   - pathlib=1.0.1=py311h38be061_7
   - pcre2=10.42=hcad00b1_0
   - pigz=2.8=h2797004_0
   - pillow=10.2.0=py311ha6c5da5_0
-  - pip=24.0=pyhd8ed1ab_0
+  - pip=24.3.1=pyh8b19718_0
   - pixman=0.43.2=h59595ed_0
   - prov=2.0.0=pyhd3deb0d_0
   - psutil=5.9.8=py311h459d7ec_0
@@ -187,7 +187,7 @@ dependencies:
   - readline=8.2=h8228510_1
   - requests=2.31.0=pyhd8ed1ab_0
   - s2n=1.4.3=h06160fa_0
-  - scikit-learn=1.4.1.post1=py311hc009520_0
+  - scikit-learn=1.5.1=py311hd632256_0
   - scipy=1.12.0=py311h64a7726_2
   - setuptools=69.1.0=pyhd8ed1ab_1
   - simplejson=3.19.2=py311h459d7ec_0
@@ -223,6 +223,7 @@ dependencies:
   - zlib=1.2.13=hd590300_5
   - zstd=1.5.5=hfc55251_0
   - pip:
-      - dcmstack==0.9
       - ancpbids<0.2.2
+      - dcmstack==0.9
       - tapipy==1.6.3
+      - pylibjpeg_libjpeg==2.1.0 # dependency of dcmstack


### PR DESCRIPTION
pylibjpeg_libjpeg is pulled in by dcmstack, and [the release notes for v2.2.0](https://github.com/pydicom/pylibjpeg-libjpeg/releases/tag/v2.2.0) mention point to the issue:

> Python3.8: uses NumPy < 2.0
Python 3.9-3.12: uses NumPy >= 2.0