### PR TITLE
Avoid sending very short fmri scans through fmriprep

### DIFF
--- a/fmriprep_actor/reactor.py
+++ b/fmriprep_actor/reactor.py
@@ -41,7 +41,7 @@ class FMRIPrepReactor(models.Reactor):
             })
             .filter(pl.col("T1 Received") == 1)
             .filter(pl.col("synthstrip") == 1)
-            .filter(pl.col("fmriprep") == 0)
+            .filter(pl.col("fmriprep-v4") == 0)
             .with_columns(
                 sublong=pl.concat_str(
                     pl.col("site"), pl.col("subject_id"), pl.col("visit")
@@ -110,7 +110,7 @@ class FMRIPrepReactor(models.Reactor):
                 name="ANAT_ONLY", value="--anat-only " + " ".join(anat_only)
             )
             self.set_app_arg(
-                name="DERIVATIVES", value="--derivatives " + " ".join(anat_only)
+                name="DERIVATIVES", value="--derivatives " + " ".join(derivatives)
             )
             self.job.name = f"{self.job_name}-{r}"
 

--- a/fmriprep_app/assets/entrypoint.py
+++ b/fmriprep_app/assets/entrypoint.py
@@ -25,7 +25,7 @@ async def main(
     output_spaces: typing.Sequence[fmriprep_models.OUTPUT_SPACE] = (
         typing.get_args(fmriprep_models.OUTPUT_SPACE)
     ),
-    anat_only: typing.Sequence[bool] | None = None,
+    anat_only: typing.MutableSequence[bool] | None = None,
     derivatives: typing.Sequence[Path] | None = None,
 ) -> None:
     await fmriprep.FMRIPRepEntrypoint(
@@ -38,7 +38,14 @@ async def main(
         dummy_scans=dummy_scans,
         bold2anat_dof=bold2anat_dof,
         output_spaces=output_spaces,
-        stage_ignore_patterns=shutil.ignore_patterns("*.heudiconv", "sourcedata"),
+        stage_ignore_patterns=shutil.ignore_patterns(
+            "*.heudiconv",
+            "sourcedata",
+            "*scans.tsv",
+            "*scans.json",
+            "*sessions.tsv",
+            "*sessions.json",
+        ),
         anat_only=anat_only,
         derivatives=derivatives,
     ).run()

--- a/fmriprep_app/pixi.lock
+++ b/fmriprep_app/pixi.lock
@@ -51,7 +51,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-gil-3.12.13-hd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.12-8_cp312.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
-      - pypi: git+https://github.com/a2cps/biomarker-extractor.git?rev=8c6868d#8c6868d95ba94fd5ef6c82c4cc1266f42ea2e9d3
+      - pypi: git+https://github.com/a2cps/biomarker-extractor.git?rev=03e72977615875167a5dfc04a22ce0068595a1fe#03e72977615875167a5dfc04a22ce0068595a1fe
       - pypi: https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/32/d5/f9a850d79b0851d1d4ef6456097579a9005b31fea68726a4ae5f2d82ddd9/threadpoolctl-3.6.0-py3-none-any.whl
@@ -626,7 +626,7 @@ packages:
   run_exports: {}
   size: 119135
   timestamp: 1767016325805
-- pypi: git+https://github.com/a2cps/biomarker-extractor.git?rev=8c6868d#8c6868d95ba94fd5ef6c82c4cc1266f42ea2e9d3
+- pypi: git+https://github.com/a2cps/biomarker-extractor.git?rev=03e72977615875167a5dfc04a22ce0068595a1fe#03e72977615875167a5dfc04a22ce0068595a1fe
   name: biomarkers
   version: 0.1.0
   requires_dist:

--- a/fmriprep_app/pixi.lock
+++ b/fmriprep_app/pixi.lock
@@ -51,7 +51,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-gil-3.12.13-hd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.12-8_cp312.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
-      - pypi: git+https://github.com/a2cps/biomarker-extractor.git?rev=03e72977615875167a5dfc04a22ce0068595a1fe#03e72977615875167a5dfc04a22ce0068595a1fe
+      - pypi: git+https://github.com/a2cps/biomarker-extractor.git?rev=dd85fc9745fae6fb647d277117470852bd6686d5#dd85fc9745fae6fb647d277117470852bd6686d5
       - pypi: https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/32/d5/f9a850d79b0851d1d4ef6456097579a9005b31fea68726a4ae5f2d82ddd9/threadpoolctl-3.6.0-py3-none-any.whl
@@ -626,7 +626,7 @@ packages:
   run_exports: {}
   size: 119135
   timestamp: 1767016325805
-- pypi: git+https://github.com/a2cps/biomarker-extractor.git?rev=03e72977615875167a5dfc04a22ce0068595a1fe#03e72977615875167a5dfc04a22ce0068595a1fe
+- pypi: git+https://github.com/a2cps/biomarker-extractor.git?rev=dd85fc9745fae6fb647d277117470852bd6686d5#dd85fc9745fae6fb647d277117470852bd6686d5
   name: biomarkers
   version: 0.1.0
   requires_dist:

--- a/fmriprep_app/pixi.toml
+++ b/fmriprep_app/pixi.toml
@@ -15,4 +15,4 @@ mpi4py = "3.1.6.*"
 polars = "1.33.1.*"
 
 [pypi-dependencies]
-biomarkers = { git = "https://github.com/a2cps/biomarker-extractor.git", rev = "03e72977615875167a5dfc04a22ce0068595a1fe" }
+biomarkers = { git = "https://github.com/a2cps/biomarker-extractor.git", rev = "dd85fc9745fae6fb647d277117470852bd6686d5" }

--- a/fmriprep_app/pixi.toml
+++ b/fmriprep_app/pixi.toml
@@ -15,4 +15,4 @@ mpi4py = "3.1.6.*"
 polars = "1.33.1.*"
 
 [pypi-dependencies]
-biomarkers = { git = "https://github.com/a2cps/biomarker-extractor.git", rev = "8c6868d" }
+biomarkers = { git = "https://github.com/a2cps/biomarker-extractor.git", rev = "03e72977615875167a5dfc04a22ce0068595a1fe" }


### PR DESCRIPTION
Should also
Close #352
Close #378
Close #379 

Meaning that the following logs can be cleared
FCN
```{bash}
$ grep -m1 -H "length of the input vector" */*err
NS10182V1/9fbc85e0-12cf-4551-964c-d00e5acf4002-007.err:    raise ValueError("The length of the input vector x must be greater "
NS10394V1/273979b6-aba5-439d-830b-3e80b2f10da9-007.err:    raise ValueError("The length of the input vector x must be greater "
NS10899V3/cc73be4c-1f15-4e10-808d-a623749383d6-007.err:    raise ValueError("The length of the input vector x must be greater "
NS11132V1/1dcbbb87-13b9-4622-ae60-7fdf87a8ed24-007.err:    raise ValueError("The length of the input vector x must be greater "
NS11387V1/61293070-88b7-483c-ae16-9daa2ed52d04-007.err:    raise ValueError("The length of the input vector x must be greater "
UM25060V3/175e79af-ffa7-40e0-abe5-882ff28b3a13-007.err:    raise ValueError("The length of the input vector x must be greater "
UM25488V3/61293070-88b7-483c-ae16-9daa2ed52d04-007.err:    raise ValueError("The length of the input vector x must be greater "

```

signatures
```{bash}
$ grep -m1 -H "length of the input vector" */*err
NS11132V1/8b8814cc-c836-4c4e-80f0-23001de1be12-007.err:    raise ValueError("The length of the input vector x must be greater "
NS11387V1/66b10f92-361f-4bba-888e-fa4c2167cf4a-007.err:    raise ValueError("The length of the input vector x must be greater "
UM25060V3/af662c9b-deb0-4b7b-b1f8-3fdf37cc6641-007.err:    raise ValueError("The length of the input vector x must be greater "
UM25488V3/66b10f92-361f-4bba-888e-fa4c2167cf4a-007.err:    raise ValueError("The length of the input vector x must be greater "
```

gift
```{bash}
$ grep -m1 -H "Index exceeds" */*log
NS11007V1/gift_rank-0_sub-11007_ses-V1_task-cuff_run-02_bold_neuromark_fmri_2.1_modelorder-multi.log:Index exceeds the number of array elements. Index must not exceed 8.
UM20546V1/gift_rank-38_sub-20546_ses-V1_task-cuff_run-02_bold_neuromark_fmri_2.1_modelorder-multi.log:Index exceeds the number of array elements. Index must not exceed 8.
```

fmriprep
```{bash}
$ grep -m1 -H "RuntimeError: Insufficient length of BOLD data"  */fmriprep*log 
NS10428V1/fmriprep_rank-0.log:	RuntimeError: Insufficient length of BOLD data (11 time points) after discarding 15 nonsteady-state (or 'dummy') time points.
NS11205V3/fmriprep_rank-7.log:	RuntimeError: Insufficient length of BOLD data (17 time points) after discarding 15 nonsteady-state (or 'dummy') time points.
NS11278V1/fmriprep_rank-4.log:	RuntimeError: Insufficient length of BOLD data (10 time points) after discarding 15 nonsteady-state (or 'dummy') time points.
UC10732V1/fmriprep_rank-133.log:	RuntimeError: Insufficient length of BOLD data (18 time points) after discarding 15 nonsteady-state (or 'dummy') time points.
UM25276V3/fmriprep_rank-92.log:	RuntimeError: Insufficient length of BOLD data (9 time points) after discarding 15 nonsteady-state (or 'dummy') time points.
UM25444V1/fmriprep_rank-31.log:	RuntimeError: Insufficient length of BOLD data (8 time points) after discarding 15 nonsteady-state (or 'dummy') time points.
```